### PR TITLE
feat: add automatic cleanup for stale budget reservations

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -69,6 +69,7 @@ CONFIG_FIELD_TYPES: Dict[str, type] = {
     # Phase 1: Operational Hardening
     'rpc_timeout_seconds': int,
     'rpc_circuit_breaker_seconds': int,
+    'reservation_timeout_hours': int,
 }
 
 # Range constraints for numeric fields
@@ -97,6 +98,7 @@ CONFIG_FIELD_RANGES: Dict[str, tuple] = {
     'rebalance_min_profit_ppm': (0, 100000),
     'rpc_timeout_seconds': (1, 300),
     'rpc_circuit_breaker_seconds': (0, 3600),
+    'reservation_timeout_hours': (1, 24),
 }
 
 
@@ -162,6 +164,7 @@ class Config:
     # Phase 1: Operational Hardening
     rpc_timeout_seconds: int = 15
     rpc_circuit_breaker_seconds: int = 60
+    reservation_timeout_hours: int = 4  # Hours before stale budget reservations auto-release
     
     # HTLC Congestion threshold
     htlc_congestion_threshold: float = 0.8  # Mark channel as CONGESTED if >80% HTLC slots used
@@ -422,6 +425,7 @@ class ConfigSnapshot:
     # Phase 1: Operational Hardening
     rpc_timeout_seconds: int
     rpc_circuit_breaker_seconds: int
+    reservation_timeout_hours: int
 
     # Hive Parameters (v1.4.0) - MAJOR-12 FIX: Added missing fields
     hive_fee_ppm: int
@@ -487,6 +491,7 @@ class ConfigSnapshot:
             enable_peer_sync=config.enable_peer_sync,
             rpc_timeout_seconds=config.rpc_timeout_seconds,
             rpc_circuit_breaker_seconds=config.rpc_circuit_breaker_seconds,
+            reservation_timeout_hours=config.reservation_timeout_hours,
             hive_fee_ppm=config.hive_fee_ppm,
             hive_rebalance_tolerance=config.hive_rebalance_tolerance,
             version=config._version,


### PR DESCRIPTION
## Summary

This PR addresses two related issues with budget reservation management:

- **Issue #23**: Missing `get_daily_rebalance_spend()` database method
- **Issue #24**: Stale budget reservations not auto-cleaned

## Changes

### Database Methods
- `get_daily_rebalance_spend()`: Returns comprehensive spending summary including:
  - `total_spent_sats`, `total_reserved_sats`
  - `job_count`, `success_count`, `failed_count`, `success_rate`
  - `stale_reservations`: Count of stale active reservations
- `count_stale_reservations()`: Counts stale reservations without releasing them

### Automatic Cleanup
- Cleanup runs on **plugin startup** (releases orphaned reservations from crashes)
- Cleanup runs **before each rebalance cycle** (prevents budget leakage)
- Timeout is configurable via `revenue-ops-reservation-timeout-hours` (default: 4 hours)

### Debug Output Enhancement
Capital controls now shows:
```json
{
  "daily_spent_sats": 200,
  "daily_reserved_sats": 100,
  "stale_reservations": 0,
  "job_count": 10,
  "success_count": 8,
  "success_rate": 80.0
}
```

### Config
New option: `revenue-ops-reservation-timeout-hours` (range: 1-24, default: 4)

## Test plan

- [x] All existing tests pass (65/65)
- [ ] Manual test: `lightning-cli revenue-rebalance debug` shows complete capital_controls
- [ ] Verify stale reservations are cleaned on startup (check logs)
- [ ] Verify cleanup runs before each rebalance cycle

Fixes: #23, #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)