### PR TITLE
feat: enable proportional budget by default with higher percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ All options can be set in your CLN config file or via `revenue-config set`.
 | `revenue-ops-rebalance-min-profit` | `10` | Minimum profit to trigger (sats) |
 | `revenue-ops-daily-budget-sats` | `5000` | Max daily rebalance spend (sats) |
 | `revenue-ops-min-wallet-reserve` | `1000000` | Minimum reserve to maintain (sats) |
-| `revenue-ops-proportional-budget` | `false` | Scale budget based on revenue |
-| `revenue-ops-proportional-budget-pct` | `0.05` | Percentage of revenue for budget |
+| `revenue-ops-proportional-budget` | `true` | Scale budget based on revenue |
+| `revenue-ops-proportional-budget-pct` | `0.30` | Percentage of revenue for budget |
 
 ### Advanced Fee Settings
 

--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -673,14 +673,14 @@ plugin.add_option(
 
 plugin.add_option(
     name='revenue-ops-proportional-budget',
-    default='false',
-    description='If true, scale daily budget based on 24h revenue (default: false)'
+    default='true',
+    description='If true, scale daily budget based on 24h revenue (default: true)'
 )
 
 plugin.add_option(
     name='revenue-ops-proportional-budget-pct',
-    default='0.05',
-    description='Percentage of 24h revenue to use as budget when proportional budget enabled (default: 0.05 = 5%)'
+    default='0.30',
+    description='Percentage of 24h revenue to use as budget when proportional budget enabled (default: 0.30 = 30%)'
 )
 
 plugin.add_option(

--- a/modules/config.py
+++ b/modules/config.py
@@ -155,9 +155,9 @@ class Config:
     min_wallet_reserve: int = 1_000_000    # Min sats (confirmed on-chain + channel spendable) before ABORT
     
     # Revenue-Proportional Budget (Phase 7: Dynamic Budget Scaling)
-    enable_proportional_budget: bool = False  # If True, scale daily budget based on revenue
-    proportional_budget_pct: float = 0.05     # Budget = max(daily_budget_sats, revenue_24h * pct)
-                                               # Default 5% of 24h revenue
+    enable_proportional_budget: bool = True   # Scale daily budget based on revenue (Issue #22)
+    proportional_budget_pct: float = 0.30     # Budget = max(daily_budget_sats, revenue_24h * pct)
+                                               # Default 30% of 24h revenue
     
     # Phase 1: Operational Hardening
     rpc_timeout_seconds: int = 15


### PR DESCRIPTION
## Summary

Enables revenue-proportional budgeting by default to prevent rebalancing failures due to insufficient budget.

## Problem

From Issue #22:
- Fixed daily budget was often insufficient for active nodes
- "Budget exhausted" errors blocking legitimate rebalances
- Proportional budgeting was disabled by default
- When enabled, used only 5% of revenue (too conservative)

## Solution

| Setting | Before | After |
|---------|--------|-------|
| `revenue-ops-proportional-budget` | `false` | `true` |
| `revenue-ops-proportional-budget-pct` | `0.05` (5%) | `0.30` (30%) |

### Budget Calculation

```
effective_budget = max(daily_budget_sats, revenue_24h * proportional_budget_pct)
                 = max(5000, revenue_24h * 0.30)
```

### Example Scenarios

| 24h Revenue | Budget Before | Budget After |
|-------------|---------------|--------------|
| 1,000 sats | 5,000 sats | 5,000 sats (floor) |
| 10,000 sats | 5,000 sats | 5,000 sats (floor) |
| 20,000 sats | 5,000 sats | 6,000 sats |
| 50,000 sats | 5,000 sats | 15,000 sats |

## Breaking Change Notice

Existing nodes with `revenue-ops-proportional-budget=false` in their config will maintain their current behavior. Only new installations or nodes without explicit config will use the new defaults.

## Test plan

- [x] All existing tests pass (65/65)
- [ ] Manual: Verify budget scales with revenue in debug output
- [ ] Manual: Confirm rebalancing doesn't exhaust budget prematurely

Fixes: #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)