### PR TITLE
Fix: Initialize heuristic_modifiers early to prevent UnboundLocalError

### DIFF
--- a/modules/fee_controller.py
+++ b/modules/fee_controller.py
@@ -4590,6 +4590,7 @@ class HillClimbingFeeController:
         new_fee_ppm = 0
         target_found = False
         is_cold_start = False  # Initialize here; may be set True in Hill Climbing branch
+        heuristic_modifiers = HeuristicModifiers()  # Initialize early; populated in Hill Climbing branch
 
         # Priority 1: Congestion (Emergency High Fee)
         if is_congested:


### PR DESCRIPTION
## Problem

The `heuristic_modifiers` variable was only initialized inside the Hill Climbing branch (line 5433) but was accessed later in the code regardless of which optimization path was taken (Thompson+AIMD or Hill Climbing).

When the Thompson+AIMD path was used, this caused:
```
cannot access local variable 'heuristic_modifiers' where it is not associated with a value
```

## Affected Channels

Observed on hive-nexus-02:
- 934275x2330x0
- 934637x549x0
- 933576x1460x0

## Fix

Initialize `heuristic_modifiers = HeuristicModifiers()` early in `_adjust_channel_fee()`, before the Thompson+AIMD / Hill Climbing branching logic.

## Testing

- [x] Fix deployed and verified on hive-nexus-02
- [x] Plugin restarted successfully
- [x] No more UnboundLocalError in logs