### PR TITLE
fix: default membership stats to 0.0 in revenue-hive-status (#36)

### DIFF
--- a/modules/hive_bridge.py
+++ b/modules/hive_bridge.py
@@ -3249,8 +3249,8 @@ class HiveFeeIntelligenceBridge:
                     "tier": membership.get("tier"),
                     "hive_id": membership.get("hive_id"),
                     "joined_at": membership.get("joined_at"),
-                    "uptime_pct": membership.get("uptime_pct"),
-                    "contribution_ratio": membership.get("contribution_ratio")
+                    "uptime_pct": membership.get("uptime_pct", 0.0),
+                    "contribution_ratio": membership.get("contribution_ratio", 0.0)
                 }
             except Exception as e:
                 self._log(f"Error fetching membership details: {e}", level="debug")


### PR DESCRIPTION
## Summary
- `revenue-hive-status` showed `null` for `uptime_pct` and `contribution_ratio` because `hive-status` didn't include these fields in its membership response
- Added defaults of `0.0` so the bridge is resilient to older cl-hive versions
- The primary fix is in cl-hive (lightning-goats/cl-hive#63) which now includes `uptime_pct` and `contribution_ratio` in the `hive-status` membership section

## Test plan
- [x] `python3 -m pytest tests/ -k hive -v` — 55/55 pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)