### PR TITLE
feat(boltz): add wallet backup and mnemonic verification

### DIFF
--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -3660,6 +3660,37 @@ def revenue_boltz_deposit(plugin: Plugin, currency: str = "lbtc") -> Dict[str, A
         return {"error": str(e)}
 
 
+@plugin.method("revenue-boltz-backup")
+def revenue_boltz_backup(plugin: Plugin) -> Dict[str, Any]:
+    """Retrieve boltzd backup info: swap mnemonic, wallet list, pending swaps.
+
+    WARNING: Response contains the swap mnemonic in plaintext.
+    Wallet BIP39 credentials require manual interactive backup via boltzcli.
+    """
+    if boltz_swaps is None:
+        return {"error": "boltz_swaps not initialized"}
+    try:
+        return boltz_swaps.get_backup_info()
+    except Exception as e:
+        plugin.log(f"Boltz backup error: {e}", level='error')
+        return {"error": str(e)}
+
+
+@plugin.method("revenue-boltz-backup-verify")
+def revenue_boltz_backup_verify(plugin: Plugin, swap_mnemonic: str) -> Dict[str, Any]:
+    """Verify a swap mnemonic backup matches the current boltzd mnemonic.
+
+    Read-only. Does not modify the current mnemonic.
+    """
+    if boltz_swaps is None:
+        return {"error": "boltz_swaps not initialized"}
+    try:
+        return boltz_swaps.verify_backup(swap_mnemonic)
+    except Exception as e:
+        plugin.log(f"Boltz backup verify error: {e}", level='error')
+        return {"error": str(e)}
+
+
 @plugin.method("revenue-cleanup-closed")
 def revenue_cleanup_closed(plugin: Plugin) -> Dict[str, Any]:
     """

--- a/modules/boltz_swaps.py
+++ b/modules/boltz_swaps.py
@@ -1893,3 +1893,91 @@ class BoltzSwapManager:
             "invoice.settled",
             "transaction.claimed",
         )
+
+    # ── Backup & recovery ───────────────────────────────────────────
+
+    def get_backup_info(self) -> Dict[str, Any]:
+        """Retrieve boltzd backup information.
+
+        Returns swap mnemonic, wallet list, pending swaps, and node identity.
+        Wallet BIP39 credentials require manual interactive backup.
+        """
+        result: Dict[str, Any] = {}
+
+        # 1. Swap mnemonic (raw text, no --json support)
+        try:
+            mnemonic = self._run_boltzcli_raw("swapmnemonic", "get").strip()
+            result["swap_mnemonic"] = mnemonic
+        except Exception as e:
+            result["swap_mnemonic"] = None
+            result["swap_mnemonic_error"] = str(e)
+
+        # 2. Wallet list with balances
+        try:
+            result["wallets"] = self._run_boltzcli("wallet", "list")
+        except Exception as e:
+            result["wallets"] = {"error": str(e)}
+
+        # 3. Pending swaps (at-risk if DB lost)
+        try:
+            swaps = self._run_boltzcli("listswaps")
+            pending = []
+            for s in swaps.get("allSwaps", []):
+                state = s.get("state", "").lower()
+                if state not in ("successful", "refunded", "cancelled"):
+                    pending.append({
+                        "id": s.get("id"),
+                        "type": s.get("type"),
+                        "state": s.get("state"),
+                        "amount": s.get("expectedAmount") or s.get("onchainAmount"),
+                        "currency": s.get("pair", {}).get("to") or s.get("pair", {}).get("from"),
+                    })
+            result["pending_swaps"] = pending
+            result["pending_swap_count"] = len(pending)
+        except Exception as e:
+            result["pending_swaps"] = []
+            result["pending_swap_error"] = str(e)
+
+        # 4. Node identity (for context)
+        try:
+            result["boltzd_info"] = self._run_boltzcli("getinfo")
+        except Exception as e:
+            result["boltzd_info"] = {"error": str(e)}
+
+        # 5. Manual backup reminder
+        wallet_names = []
+        for w in result.get("wallets", {}).get("wallets", []):
+            wallet_names.append(w.get("name", "unknown"))
+        result["manual_backup_required"] = {
+            "description": "BIP39 wallet credentials must be backed up interactively",
+            "command": [f"boltzcli wallet credentials {n}" for n in wallet_names],
+        }
+
+        self._record_audit_event(
+            "backup_info_accessed",
+            "Boltzd backup information was retrieved (includes swap mnemonic)",
+        )
+
+        return result
+
+    def verify_backup(self, swap_mnemonic: str) -> Dict[str, Any]:
+        """Verify a backup swap mnemonic matches the current one.
+
+        Read-only check — does NOT modify the current mnemonic.
+        """
+        if not swap_mnemonic or not isinstance(swap_mnemonic, str):
+            return {"verified": False, "error": "swap_mnemonic is required"}
+
+        try:
+            current = self._run_boltzcli_raw("swapmnemonic", "get").strip()
+        except Exception as e:
+            return {"verified": False, "error": f"Could not retrieve current mnemonic: {e}"}
+
+        match = swap_mnemonic.strip() == current
+
+        self._record_audit_event(
+            "backup_verified",
+            f"Swap mnemonic backup verification: {'MATCH' if match else 'MISMATCH'}",
+        )
+
+        return {"verified": True, "match": match}

--- a/tests/test_boltz_swaps.py
+++ b/tests/test_boltz_swaps.py
@@ -2073,3 +2073,89 @@ def test_chain_swap_no_address_uses_to_wallet():
             break
     else:
         assert False, "createchainswap call not found"
+
+
+# ── Backup tests ─────────────────────────────────────────────────
+
+
+def test_get_backup_info():
+    """get_backup_info returns swap mnemonic, wallets, pending swaps, boltzd info."""
+    manager, _ = _make_manager()
+
+    with patch.object(manager, '_run_boltzcli_raw', return_value="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12\n"):
+        with patch.object(manager, '_run_boltzcli') as mock_cli:
+            mock_cli.side_effect = [
+                {"wallets": [{"name": "CLN", "currency": "BTC", "balance": {"confirmed": "100000"}}]},
+                {"allSwaps": [
+                    {"id": "abc", "type": "reverse", "state": "pending", "expectedAmount": 50000, "pair": {"to": "BTC"}},
+                    {"id": "def", "type": "submarine", "state": "successful", "expectedAmount": 25000, "pair": {"from": "BTC"}},
+                ]},
+                {"version": "v2.11.0", "nodePubkey": "03abc", "network": "mainnet"},
+            ]
+            result = manager.get_backup_info()
+
+    assert result["swap_mnemonic"] == "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12"
+    assert len(result["wallets"]["wallets"]) == 1
+    assert result["pending_swap_count"] == 1  # only "pending" one, not "successful"
+    assert result["pending_swaps"][0]["id"] == "abc"
+    assert "manual_backup_required" in result
+    assert result["manual_backup_required"]["command"] == ["boltzcli wallet credentials CLN"]
+
+
+def test_get_backup_info_mnemonic_error():
+    """get_backup_info handles swapmnemonic failure gracefully."""
+    manager, _ = _make_manager()
+
+    with patch.object(manager, '_run_boltzcli_raw', side_effect=RuntimeError("boltzd not running")):
+        with patch.object(manager, '_run_boltzcli') as mock_cli:
+            mock_cli.side_effect = [
+                {"wallets": []},
+                {"allSwaps": []},
+                {"version": "v2.11.0"},
+            ]
+            result = manager.get_backup_info()
+
+    assert result["swap_mnemonic"] is None
+    assert "swap_mnemonic_error" in result
+
+
+def test_verify_backup_match():
+    """verify_backup returns match=True when mnemonics match."""
+    manager, _ = _make_manager()
+
+    with patch.object(manager, '_run_boltzcli_raw', return_value="word1 word2 word3\n"):
+        result = manager.verify_backup("word1 word2 word3")
+    assert result["verified"] is True
+    assert result["match"] is True
+
+
+def test_verify_backup_mismatch():
+    """verify_backup returns match=False when mnemonics differ."""
+    manager, _ = _make_manager()
+
+    with patch.object(manager, '_run_boltzcli_raw', return_value="word1 word2 word3\n"):
+        result = manager.verify_backup("wrong wrong wrong")
+    assert result["verified"] is True
+    assert result["match"] is False
+
+
+def test_verify_backup_empty():
+    """verify_backup rejects empty mnemonic."""
+    manager, _ = _make_manager()
+    result = manager.verify_backup("")
+    assert result["verified"] is False
+    assert "error" in result
+
+
+def test_get_backup_info_audit_event():
+    """get_backup_info records an audit event."""
+    manager, _ = _make_manager()
+
+    with patch.object(manager, '_run_boltzcli_raw', return_value="mnemonic words\n"):
+        with patch.object(manager, '_run_boltzcli', return_value={}):
+            with patch.object(manager, '_record_audit_event') as mock_audit:
+                manager.get_backup_info()
+    mock_audit.assert_called_once_with(
+        "backup_info_accessed",
+        "Boltzd backup information was retrieved (includes swap mnemonic)",
+    )


### PR DESCRIPTION
## Summary
- Add `get_backup_info()` method to retrieve swap mnemonic, wallet list, pending swaps, and boltzd identity programmatically
- Add `verify_backup()` method for read-only mnemonic comparison against current boltzd state
- Expose as `revenue-boltz-backup` and `revenue-boltz-backup-verify` RPC commands
- Wallet BIP39 credentials still require manual interactive `boltzcli wallet credentials <name>` (Go survey library panics in subprocess)

## Test plan
- [x] 6 new tests covering happy path, error handling, mismatch, empty input, and audit trail
- [x] All 111 existing tests pass
- [ ] Live validation: `lightning-cli revenue-boltz-backup` returns swap mnemonic + wallet list
- [ ] Live validation: `lightning-cli revenue-boltz-backup-verify swap_mnemonic="<mnemonic>"` returns match=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)