### PR TITLE
fix: clear hive breaker on startup retries

### DIFF
--- a/modules/hive_bridge.py
+++ b/modules/hive_bridge.py
@@ -259,9 +259,23 @@ class HiveFeeIntelligenceBridge:
             self._availability_lock.release()
 
     def invalidate_availability(self) -> None:
-        """Force a fresh availability check on next is_available() call."""
+        """Force a fresh availability check on next is_available() call.
+
+        Also clears the hive RPC breaker so the retry actually reaches CLN
+        instead of being short-circuited.  This is safe because invalidate is
+        only called when we *want* a fresh probe (startup retries, explicit
+        reset) — not on every call.
+        """
         self._hive_available = None
         self._availability_check_time = 0
+        # Clear the hive group breaker so the next is_available() can make
+        # real RPC calls instead of hitting the short-circuit.
+        try:
+            rpc_proxy = self.plugin.rpc
+            if hasattr(rpc_proxy, '_breakers'):
+                rpc_proxy._breakers.pop("hive", None)
+        except Exception:
+            pass
 
     # =========================================================================
     # CIRCUIT BREAKER


### PR DESCRIPTION
## Summary

- Follow-up to #42 — the pool starvation fix introduced a breaker short-circuit in `is_available()` that inadvertently blocked startup retries
- When `hive-status` times out during startup (cl-hive still loading), the 60s circuit breaker trips, and subsequent retry attempts return `False` instantly without ever making an RPC call
- `invalidate_availability()` now also clears the hive group breaker, so each startup retry gets a real shot at reaching cl-hive

## Test plan

- [x] `py_compile` passes
- [x] All 619 tests pass
- [ ] Deploy and verify startup logs show real retries instead of instant failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)