### PR TITLE
fix: add COALESCE to SUM() in capital controls query

### DIFF
--- a/modules/database.py
+++ b/modules/database.py
@@ -2273,9 +2273,9 @@ class Database:
             SELECT
                 COALESCE(SUM(CASE WHEN status = 'success' THEN actual_fee_sats ELSE 0 END), 0) as total_spent,
                 COUNT(*) as job_count,
-                SUM(CASE WHEN status IN ('success', 'failed', 'partial', 'timeout') THEN 1 ELSE 0 END) as completed_count,
-                SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success_count,
-                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed_count
+                COALESCE(SUM(CASE WHEN status IN ('success', 'failed', 'partial', 'timeout') THEN 1 ELSE 0 END), 0) as completed_count,
+                COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count,
+                COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count
             FROM rebalance_history
             WHERE timestamp >= ?
         """, (cutoff,)).fetchone()


### PR DESCRIPTION
## Summary
- Wraps two bare `SUM()` calls with `COALESCE(..., 0)` in `get_daily_rebalance_spend()` to prevent `None` values when `rebalance_history` is empty
- Fixes capital controls crash on new nodes with zero rebalance history
- Matches the pattern already used on the adjacent `total_spent` aggregation

## Test plan
- [ ] Verify `revenue-rebalance-debug` returns clean `capital_controls` on a node with no rebalance history
- [ ] Verify automated rebalancing is no longer blocked by the `NoneType` comparison error
- [ ] Run `python3 -m pytest tests/ -k "test_rebalance"`

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)