### PR TITLE
fix: give hive cross-plugin RPCs 2x timeout

### DIFF
--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -299,6 +299,10 @@ class ThreadSafeRpcProxy:
         timeout = 30
         if config:
             timeout = config.rpc_timeout_seconds
+        # Cross-plugin RPCs (hive-*) relay through CLN and are inherently
+        # slower — give them 2x the normal timeout to avoid spurious failures.
+        if method_name.startswith("hive-"):
+            timeout *= 2
         future = self._executor.submit(
             self._rpc.call, method_name, payload if payload is not None else {},
         )


### PR DESCRIPTION
## Summary
- Cross-plugin RPCs (`hive-*`) relay through CLN and are inherently slower than direct lightningd calls
- Apply 2x timeout multiplier in `ResilientRPCProxy.call()` to avoid spurious failures when cl-hive is under load
- This commit was part of #51 but merged before it was pushed

## Test plan
- [x] All 619 tests pass
- [ ] Verify hive RPCs no longer timeout at 15s under normal load

🤖 Generated with [Claude Code](https://claude.com/claude-code)