### PR TITLE
Harden native rebalance execution and routing reliability

### DIFF
--- a/modules/database.py
+++ b/modules/database.py
@@ -3930,10 +3930,52 @@ class Database:
             avg_cost_ppm, and avg_amount_sats.
             Returns None if no rebalance history for this channel.
         """
+        return self._get_rebalance_success_rate_for_where(
+            "to_channel = ?",
+            (channel_id,),
+            window_days=window_days,
+        )
+
+    def get_source_rebalance_success_rate(
+        self, channel_id: str, window_days: int = 30
+    ) -> Optional[Dict[str, Any]]:
+        """Get source-channel rebalance success rate from rebalance_history."""
+        return self._get_rebalance_success_rate_for_where(
+            "from_channel = ?",
+            (channel_id,),
+            window_days=window_days,
+        )
+
+    def get_peer_rebalance_success_rate(
+        self, peer_id: str, window_days: int = 30
+    ) -> Optional[Dict[str, Any]]:
+        """Get destination-peer rebalance success rate aggregated across its channels."""
+        conn = self._get_connection()
+        peer_channels = conn.execute("""
+            SELECT channel_id FROM channel_states WHERE peer_id = ?
+        """, (peer_id,)).fetchall()
+        if not peer_channels:
+            return None
+        channel_ids = [row["channel_id"] for row in peer_channels]
+        placeholders = ",".join("?" * len(channel_ids))
+        return self._get_rebalance_success_rate_for_where(
+            f"to_channel IN ({placeholders})",
+            tuple(channel_ids),
+            window_days=window_days,
+        )
+
+    def _get_rebalance_success_rate_for_where(
+        self,
+        where_sql: str,
+        where_params: tuple,
+        *,
+        window_days: int = 30,
+    ) -> Optional[Dict[str, Any]]:
+        """Shared aggregate helper for rebalance success-rate queries."""
         conn = self._get_connection()
         cutoff = int(time.time()) - (window_days * 86400)
 
-        row = conn.execute("""
+        row = conn.execute(f"""
             SELECT
                 COUNT(*) as total,
                 SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as successes,
@@ -3943,8 +3985,8 @@ class Database:
                     ELSE NULL END) as avg_cost_ppm,
                 AVG(CASE WHEN status = 'success' THEN amount_sats ELSE NULL END) as avg_amount
             FROM rebalance_history
-            WHERE to_channel = ? AND timestamp >= ?
-        """, (channel_id, cutoff)).fetchone()
+            WHERE {where_sql} AND timestamp >= ?
+        """, (*where_params, cutoff)).fetchone()
 
         if not row or row['total'] == 0:
             return None

--- a/modules/rebalance_executor.py
+++ b/modules/rebalance_executor.py
@@ -1,12 +1,10 @@
 """
-rebalance_executor — Native rebalance engine using getroutes + sendpay.
+rebalance_executor — Native rebalance engine using safe explicit routes.
 
-Replaces sling for rebalance execution with full askrene layer support.
-Fleet rebalances route through zero-fee fleet peers.  Network rebalances
-use the best available paths with profitability biases.  Both learn from
-results via askrene-inform-channel.
-
-Supports MPP (multi-part payments) for large rebalances.
+Replaces sling for rebalance execution while keeping askrene and hive data on
+the planning side. Fleet-planned and network-planned rebalances both execute
+through a single explicit-route `getroute` + `sendpay` model with retry,
+transient routing memory, and askrene result feedback.
 """
 
 from __future__ import annotations
@@ -18,6 +16,8 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set
+
+from modules.rebalance_memory import RebalanceRoutingMemory
 
 
 class JobState(Enum):
@@ -65,12 +65,12 @@ class RebalanceJob:
 
 
 class RebalanceExecutor:
-    """Native rebalance execution using getroutes + sendpay.
+    """Native rebalance execution using explicit circular routes.
 
-    Fleet rebalances use all hive-* + revenue-* askrene layers for
-    zero-fee fleet routing.  Network rebalances use revenue-* layers
-    for optimal path selection.  Both learn from results via
-    askrene-inform-channel.
+    Fleet and network rebalances share the same safe execution path:
+    build one explicit route, validate it, send it, and learn from the
+    result. Askrene and hive layers still inform planning and route
+    selection upstream.
 
     Thread-safe: jobs run in a ThreadPoolExecutor.
     """
@@ -81,12 +81,15 @@ class RebalanceExecutor:
     NETWORK_MAX_PARTS = 3
     SENDPAY_TIMEOUT = 60
     INVOICE_EXPIRY = 300
+    CHANNEL_BAN_TTL = 300
+    FIRST_HOP_BAN_TTL = 60
 
     def __init__(self, plugin, config, database, hive_router=None):
         self.plugin = plugin
         self.config = config
         self.database = database
         self.hive_router = hive_router
+        self._routing_memory = RebalanceRoutingMemory()
         self._our_id: Optional[str] = None
         self._pool = ThreadPoolExecutor(max_workers=self.MAX_CONCURRENT,
                                         thread_name_prefix="rebal")
@@ -325,8 +328,9 @@ class RebalanceExecutor:
             "maxhops": 6,
             "fuzzpercent": 0,
         }
-        if excludes:
-            getroute_kwargs["exclude"] = excludes
+        merged_excludes = list(dict.fromkeys(excludes + self._routing_memory.current_excludes()))
+        if merged_excludes:
+            getroute_kwargs["exclude"] = merged_excludes
 
         route_result = self.plugin.rpc.getroute(
             candidate.to_peer_id,
@@ -417,6 +421,85 @@ class RebalanceExecutor:
             "short_channel_id_dir": f"{candidate.to_channel.replace(':', 'x')}/{final_direction}",
         })
         return full_route, inform_path
+
+    def _learn_from_failure(
+        self,
+        full_route: List[Dict],
+        failure: Dict[str, Any],
+        exc: Exception,
+    ) -> None:
+        """Record short-lived routing memory from a failed attempt."""
+        if not full_route:
+            return
+
+        if getattr(exc, "command", "") == "sendpay":
+            direction = full_route[0].get("direction")
+            if direction is not None:
+                self._routing_memory.ban_channel(
+                    f"{full_route[0]['channel']}/{direction}",
+                    ttl_seconds=self.FIRST_HOP_BAN_TTL,
+                )
+            return
+
+        code = failure.get("code")
+        if code != 204:
+            return
+
+        erring_channel = failure.get("erring_channel")
+        erring_direction = failure.get("erring_direction")
+        erring_node = failure.get("erring_node")
+        failcodename = failure.get("failcodename", "")
+        erring_index = int(failure.get("erring_index") or 0)
+        is_node_error = bool(int(failure.get("failcode", 0) or 0) & 0x2000)
+
+        if is_node_error and erring_node:
+            self._routing_memory.ban_node(erring_node, ttl_seconds=self.CHANNEL_BAN_TTL)
+
+        if erring_channel and erring_direction is not None:
+            scid_dir = f"{erring_channel}/{erring_direction}"
+            if failcodename == "WIRE_TEMPORARY_CHANNEL_FAILURE":
+                self._routing_memory.ban_channel(scid_dir, ttl_seconds=self.CHANNEL_BAN_TTL)
+                amount_idx = min(max(erring_index - 1, 0), len(full_route) - 1)
+                constrained_amount = max(
+                    0,
+                    int(full_route[amount_idx].get("amount_msat", 0) or 0) - 1,
+                )
+                if constrained_amount > 0:
+                    self._routing_memory.constrain_channel(
+                        scid_dir,
+                        constrained_amount,
+                        ttl_seconds=self.CHANNEL_BAN_TTL,
+                    )
+
+    def _route_constraint_excludes(
+        self,
+        full_route: List[Dict],
+        candidate,
+        our_id: str,
+        amount_msat: int,
+    ) -> List[str]:
+        """Return hops that exceed remembered max-amount constraints."""
+        excludes: List[str] = []
+        for hop in full_route:
+            channel = hop.get("channel")
+            direction = hop.get("direction")
+            if not channel or direction is None:
+                continue
+            scid_dir = f"{channel}/{direction}"
+            max_amount = self._routing_memory.max_amount_for(scid_dir)
+            if max_amount is None:
+                continue
+            hop_amount = int(hop.get("amount_msat", 0) or 0)
+            if hop_amount > max_amount:
+                excludes.append(scid_dir)
+
+        final_direction = 1 if candidate.to_peer_id > our_id else 0
+        final_scid_dir = f"{candidate.to_channel.replace(':', 'x')}/{final_direction}"
+        final_max = self._routing_memory.max_amount_for(final_scid_dir)
+        if final_max is not None and amount_msat > final_max:
+            excludes.append(final_scid_dir)
+
+        return list(dict.fromkeys(excludes))
 
     def _compute_fleet_route(
         self,
@@ -511,6 +594,14 @@ class RebalanceExecutor:
                 full_route, inform_path = self._compute_network_route(
                     job, candidate, our_id, excludes
                 )
+                constraint_excludes = self._route_constraint_excludes(
+                    full_route, candidate, our_id, job.amount_msat
+                )
+                if constraint_excludes:
+                    excludes = list(dict.fromkeys(excludes + constraint_excludes))
+                    if attempt < self.MAX_ATTEMPTS:
+                        continue
+                    raise ValueError("constrained_route")
                 self._validate_sendpay_route(full_route, job.amount_msat)
 
                 total_fee = max(0, full_route[0].get("amount_msat", job.amount_msat) - job.amount_msat)
@@ -567,6 +658,7 @@ class RebalanceExecutor:
             except Exception as e:
                 failure = self._parse_failure(e)
                 last_error = f"sendpay_error: {e}"
+                self._learn_from_failure(full_route, failure, e)
                 if inform_path:
                     self._inform_result(inform_path, job.amount_msat, succeeded=False)
                 self._cleanup_failed_payment(job.payment_hash)

--- a/modules/rebalance_executor.py
+++ b/modules/rebalance_executor.py
@@ -170,6 +170,73 @@ class RebalanceExecutor:
         })
         return route
 
+    def _get_return_hop_policy(
+        self,
+        candidate,
+        amount_msat: int,
+        our_id: str,
+    ) -> tuple[int, int]:
+        """Amount and CLTV the destination peer needs to forward back to us."""
+        scid = candidate.to_channel.replace(":", "x")
+        base_msat = 0
+        fee_ppm = 0
+        cltv_delta = 6
+
+        try:
+            chans = self.plugin.rpc.listpeerchannels(candidate.to_peer_id)
+            for ch in chans.get("channels", []):
+                if ch.get("short_channel_id") != scid:
+                    continue
+                remote = ch.get("updates", {}).get("remote", {})
+                fee_ppm_val = remote.get("fee_proportional_millionths")
+                if fee_ppm_val is not None:
+                    fee_ppm = int(fee_ppm_val or 0)
+                fee_base_val = remote.get("fee_base_msat")
+                if fee_base_val is not None:
+                    base_msat = int(fee_base_val or 0)
+                cltv_val = remote.get("cltv_expiry_delta")
+                if cltv_val is not None:
+                    cltv_delta = int(cltv_val or 6)
+                break
+        except Exception:
+            pass
+
+        if fee_ppm == 0 and base_msat == 0:
+            try:
+                chans = self.plugin.rpc.listchannels(source=candidate.to_peer_id)
+                for ch in chans.get("channels", []):
+                    if ch.get("destination") != our_id:
+                        continue
+                    if ch.get("short_channel_id") != scid:
+                        continue
+                    fee_ppm = int(ch.get("fee_per_millionth", 0) or 0)
+                    base_msat = int(ch.get("base_fee_millisatoshi", 0) or 0)
+                    cltv_delta = int(ch.get("delay", 6) or 6)
+                    break
+            except Exception:
+                pass
+
+        required_amount_msat = amount_msat + base_msat + (amount_msat * fee_ppm) // 1_000_000
+        required_cltv = 18 + cltv_delta
+        return required_amount_msat, required_cltv
+
+    def _validate_sendpay_route(self, route: List[Dict], final_amount_msat: int) -> None:
+        """Reject malformed routes before they can crash lightningd."""
+        if not route:
+            raise ValueError("empty_route")
+
+        previous_amount = None
+        for hop in route:
+            amount = int(hop.get("amount_msat", 0) or 0)
+            if amount <= 0:
+                raise ValueError("non_positive_route_amount")
+            if previous_amount is not None and amount > previous_amount:
+                raise ValueError("increasing_route_amount")
+            previous_amount = amount
+
+        if int(route[0].get("amount_msat", 0) or 0) < int(final_amount_msat):
+            raise ValueError("insufficient_first_hop_amount")
+
     # ------------------------------------------------------------------
     # Learning
     # ------------------------------------------------------------------
@@ -240,12 +307,18 @@ class RebalanceExecutor:
         candidate,
         our_id: str,
         excludes: List[str],
-    ) -> List[Dict]:
-        """Build a circular route using getroute for network rebalances."""
+    ) -> tuple[List[Dict], List[Dict]]:
+        """Build a safe explicit circular route using getroute."""
         source_scid = candidate.source_candidates[0] if candidate.source_candidates else ""
         source_peer = candidate.primary_source_peer_id
         if not source_scid or not source_peer:
             raise ValueError("no_source_channel")
+
+        required_amount_msat, required_cltv = self._get_return_hop_policy(
+            candidate,
+            job.amount_msat,
+            our_id,
+        )
 
         getroute_kwargs = {
             "fromid": source_peer,
@@ -256,9 +329,9 @@ class RebalanceExecutor:
             getroute_kwargs["exclude"] = excludes
 
         route_result = self.plugin.rpc.getroute(
-            our_id,
-            job.amount_msat,
-            1,
+            candidate.to_peer_id,
+            required_amount_msat,
+            required_cltv,
             **getroute_kwargs,
         )
         route = route_result.get("route", [])
@@ -322,14 +395,28 @@ class RebalanceExecutor:
         first_hop_delay = route[0].get("delay", 18) + source_cltv_delta
         first_hop_direction = 1 if our_id > source_peer else 0
 
-        return [{
+        first_hop = {
             "id": source_peer,
             "channel": first_hop_scid,
             "direction": first_hop_direction,
             "amount_msat": first_hop_amount,
             "delay": first_hop_delay,
             "style": "tlv",
-        }] + route
+        }
+        final_hop = {
+            "id": our_id,
+            "channel": candidate.to_channel.replace(":", "x"),
+            "amount_msat": job.amount_msat,
+            "delay": 18,
+            "style": "tlv",
+        }
+        full_route = [first_hop] + route + [final_hop]
+        final_direction = 1 if candidate.to_peer_id > our_id else 0
+        inform_path = self._path_for_inform([first_hop] + route)
+        inform_path.append({
+            "short_channel_id_dir": f"{candidate.to_channel.replace(':', 'x')}/{final_direction}",
+        })
+        return full_route, inform_path
 
     def _compute_fleet_route(
         self,
@@ -380,8 +467,9 @@ class RebalanceExecutor:
     def _execute_single(self, job: RebalanceJob, candidate) -> RebalanceResult:
         """Execute a rebalance job.
 
-        Uses sendpay with explicit routes. Network rebalances use getroute and
-        explicit excludes on retry. Fleet rebalances use layer-aware getroutes.
+        Uses sendpay with explicit routes. Both network and fleet-planned
+        rebalances currently execute through getroute-based explicit routes.
+        Retry behavior uses explicit excludes on subsequent attempts.
         """
         our_id = self._get_our_id()
         if not our_id:
@@ -420,11 +508,10 @@ class RebalanceExecutor:
             full_route: List[Dict] = []
             inform_path: List[Dict] = []
             try:
-                if route_type == "fleet":
-                    full_route, inform_path = self._compute_fleet_route(job, candidate, our_id)
-                else:
-                    full_route = self._compute_network_route(job, candidate, our_id, excludes)
-                    inform_path = self._path_for_inform(full_route)
+                full_route, inform_path = self._compute_network_route(
+                    job, candidate, our_id, excludes
+                )
+                self._validate_sendpay_route(full_route, job.amount_msat)
 
                 total_fee = max(0, full_route[0].get("amount_msat", job.amount_msat) - job.amount_msat)
                 fee_ppm = (total_fee * 1_000_000) // job.amount_msat if job.amount_msat > 0 else 0

--- a/modules/rebalance_memory.py
+++ b/modules/rebalance_memory.py
@@ -1,0 +1,62 @@
+"""Transient routing memory for native rebalancing.
+
+Tracks short-lived bans and amount constraints learned from recent failures so
+subsequent `getroute` calls can avoid obviously bad channels and nodes.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, Optional
+
+
+class RebalanceRoutingMemory:
+    """Stores short-lived routing exclusions and channel constraints."""
+
+    def __init__(self) -> None:
+        self._channel_bans: Dict[str, float] = {}
+        self._node_bans: Dict[str, float] = {}
+        self._channel_constraints: Dict[str, tuple[int, float]] = {}
+
+    def _cleanup(self, now: Optional[float] = None) -> None:
+        now = time.time() if now is None else now
+        self._channel_bans = {
+            key: expiry for key, expiry in self._channel_bans.items()
+            if expiry > now
+        }
+        self._node_bans = {
+            key: expiry for key, expiry in self._node_bans.items()
+            if expiry > now
+        }
+        self._channel_constraints = {
+            key: value for key, value in self._channel_constraints.items()
+            if value[1] > now
+        }
+
+    def ban_channel(self, scid_dir: str, ttl_seconds: int, now: Optional[float] = None) -> None:
+        now = time.time() if now is None else now
+        self._channel_bans[scid_dir] = now + ttl_seconds
+        self._cleanup(now)
+
+    def ban_node(self, node_id: str, ttl_seconds: int, now: Optional[float] = None) -> None:
+        now = time.time() if now is None else now
+        self._node_bans[node_id] = now + ttl_seconds
+        self._cleanup(now)
+
+    def constrain_channel(
+        self, scid_dir: str, max_amount_msat: int, ttl_seconds: int, now: Optional[float] = None
+    ) -> None:
+        now = time.time() if now is None else now
+        self._channel_constraints[scid_dir] = (max_amount_msat, now + ttl_seconds)
+        self._cleanup(now)
+
+    def current_excludes(self, now: Optional[float] = None) -> list[str]:
+        self._cleanup(now)
+        return sorted([*self._channel_bans.keys(), *self._node_bans.keys()])
+
+    def max_amount_for(self, scid_dir: str, now: Optional[float] = None) -> Optional[int]:
+        self._cleanup(now)
+        value = self._channel_constraints.get(scid_dir)
+        if not value:
+            return None
+        return value[0]

--- a/modules/rebalancer.py
+++ b/modules/rebalancer.py
@@ -8,7 +8,7 @@ This module only triggers rebalances when the math shows positive expected profi
 
 Architecture Pattern: "Strategist and Executor"
 - STRATEGIST (EVRebalancer): Calculates EV, determines IF and HOW MUCH to rebalance
-- EXECUTOR (RebalanceExecutor): Actually executes payments via native getroutes+sendpay
+- EXECUTOR (RebalanceExecutor): Executes native safe single-path circular payments
 
 Async Job Queue
 - Decouples decision-making from execution
@@ -209,7 +209,7 @@ class JobManager:
     DEPRECATED: Sling-based background rebalancing job manager.
 
     JobManager is no longer called from the active rebalance path.
-    RebalanceExecutor (native getroutes+sendpay) replaced it as the primary
+    RebalanceExecutor replaced it as the primary
     execution engine. This class is retained because diagnostic RPCs may still
     reference it for active job counts. Do not add new sling dependencies here.
     """
@@ -1916,7 +1916,7 @@ class EVRebalancer:
 
     This class acts as the "Strategist" - it calculates EV and determines
     IF and HOW MUCH to rebalance. The actual execution is delegated to
-    RebalanceExecutor (native getroutes+sendpay).
+    RebalanceExecutor.
 
     Thread Safety (I-13, I-14, S-9):
     The rebalance cycle runs single-threaded on a timer. Candidate evaluation,
@@ -1973,7 +1973,7 @@ class EVRebalancer:
         # Hive hints adapter (injected by main plugin; None = disabled)
         self.hive_hints = None
         self._hive_router = None  # HiveRouter for fleet route discovery
-        self.rebalance_executor = None  # RebalanceExecutor (native getroutes+sendpay)
+        self.rebalance_executor = None  # RebalanceExecutor (safe explicit-route executor)
         self.rpc_cache = None  # Shared RPC cache (injected by main plugin)
 
     @property
@@ -4196,8 +4196,9 @@ target_ratio={target_ratio:.0%} vel={velocity:.3f} roi={float(hot_profile.get('m
         """
         Execute a rebalance for the given candidate.
 
-        Uses RebalanceExecutor (native getroutes+sendpay) for all rebalances.
-        Fleet routes use hive-* layers, network routes use revenue-* layers.
+        Uses RebalanceExecutor for all live rebalances.
+        Fleet intelligence still influences planning, but execution uses the
+        safe explicit-route path for both fleet-planned and network-planned jobs.
         """
         result = {"success": False, "candidate": candidate.to_dict(), "message": ""}
         with self._pending_lock:
@@ -4364,8 +4365,8 @@ target_ratio={target_ratio:.0%} vel={velocity:.3f} roi={float(hot_profile.get('m
                         self._pending.pop(candidate.to_channel, None)
                     return result
 
-            # RebalanceExecutor: native getroutes+sendpay for ALL rebalances.
-            # Fleet routes use hive-* layers (0-fee fleet paths).
+            # RebalanceExecutor: safe explicit-route execution for all rebalances.
+            # Fleet planning still uses hive intelligence before execution.
             # Network routes use revenue-* layers (best available paths).
             if self.rebalance_executor:
                 try:

--- a/modules/rebalancer.py
+++ b/modules/rebalancer.py
@@ -2161,6 +2161,70 @@ class EVRebalancer:
             return ev_max_fee_ppm
         return min(int(last_attempted_ppm * 1.5), ev_max_fee_ppm)
 
+    @staticmethod
+    def _normalize_rebalance_success_signal(
+        data: Optional[Dict[str, Any]],
+        *,
+        min_samples: int = 3,
+    ) -> Optional[Dict[str, float]]:
+        """Normalize rebalance success-rate history into a bounded weighted signal."""
+        if not data:
+            return None
+        total = int(data.get("total", 0) or 0)
+        if total < min_samples:
+            return None
+        rate = max(0.10, min(0.95, float(data.get("success_rate", 0.0) or 0.0)))
+        confidence = max(0.0, min(1.0, total / 10.0))
+        return {"rate": rate, "confidence": confidence, "total": total}
+
+    def _estimate_rebalance_success_probability(
+        self,
+        *,
+        dest_peer_id: str,
+        dest_channel: str,
+        source_channel: str,
+    ) -> float:
+        """Blend forwarding reputation with rebalance-specific history."""
+        signals: List[tuple[float, float]] = []
+
+        try:
+            reputation = self.database.get_peer_reputation(dest_peer_id)
+            rep_score = float(reputation.get("score", 0.5) or 0.5)
+        except Exception:
+            rep_score = 0.5
+        signals.append((max(0.10, min(0.95, rep_score)), 0.20))
+
+        signal_sources = [
+            (
+                getattr(self.database, "get_peer_rebalance_success_rate", lambda *_a, **_k: None)(
+                    dest_peer_id, 30
+                ),
+                0.30,
+            ),
+            (
+                self.database.get_channel_rebalance_success_rate(dest_channel, 30),
+                0.30,
+            ),
+            (
+                getattr(self.database, "get_source_rebalance_success_rate", lambda *_a, **_k: None)(
+                    source_channel, 30
+                ),
+                0.20,
+            ),
+        ]
+
+        for raw_signal, base_weight in signal_sources:
+            signal = self._normalize_rebalance_success_signal(raw_signal)
+            if signal is None:
+                continue
+            signals.append((signal["rate"], base_weight * signal["confidence"]))
+
+        total_weight = sum(weight for _, weight in signals)
+        if total_weight <= 0:
+            return 0.5
+        probability = sum(rate * weight for rate, weight in signals) / total_weight
+        return max(0.10, min(0.95, probability))
+
     def _parse_msat(self, v: Any) -> int:
         """Delegate to shared parse_msat in utils.py."""
         return _shared_parse_msat(v)
@@ -3068,6 +3132,11 @@ target_ratio={target_ratio:.0%} vel={velocity:.3f} roi={float(hot_profile.get('m
         max_budget_msat = max(1000, raw_budget_msat)
         # Use ceiling sats for conservative accounting.
         max_budget_sats = (max_budget_msat + 999) // 1000
+        route_success_prob = self._estimate_rebalance_success_probability(
+            dest_peer_id=dest_peer_id,
+            dest_channel=dest_channel,
+            source_channel=primary_source_id,
+        )
         
         # MAJOR-13 DOCUMENTATION: Modified Kelly Criterion for Per-Trade Sizing
         #
@@ -3088,8 +3157,7 @@ target_ratio={target_ratio:.0%} vel={velocity:.3f} roi={float(hot_profile.get('m
         # total routing capital. For daily budget management, see reserve_budget().
 
         if self.config.enable_kelly:
-            reputation = self.database.get_peer_reputation(dest_info.get("peer_id", ""))
-            historical_p = reputation.get('score', 0.5)  # Historical success probability
+            historical_p = route_success_prob
 
             # EV v2.0: Blend AskRene real-time liquidity belief with historical reputation.
             # AskRene tracks maximum believed capacity per channel direction from
@@ -3231,13 +3299,15 @@ target_ratio={target_ratio:.0%} vel={velocity:.3f} roi={float(hot_profile.get('m
 
         expected_income = int((rebalance_amount * expected_utilization * outbound_fee_ppm) // 1_000_000)
 
-        # Source reliability: discount income by probability the rebalance succeeds.
-        # Uses primary source's failure history — high failure count = lower success prob.
+        # Discount expected income by the probability that the rebalance itself succeeds.
+        # This blends forwarding reputation, rebalance-specific history, and short-lived
+        # source failures so unreliable routes stop looking artificially profitable.
         source_fail_count = self.job_manager.get_source_failure_count(primary_source_id)
         if source_fail_count > 0:
             # Exponential decay: 0 fails=100%, 1 fail=80%, 2 fails=64%, 4 fails=41%
-            source_success_prob = max(0.1, 0.8 ** source_fail_count)
-            expected_income = int(expected_income * source_success_prob)
+            route_success_prob *= max(0.1, 0.8 ** source_fail_count)
+            route_success_prob = max(0.1, min(0.95, route_success_prob))
+        expected_income = int(expected_income * route_success_prob)
 
         # Corridor ownership is a bounded, confidence-weighted utilization prior.
         expected_income = int(
@@ -4043,6 +4113,22 @@ target_ratio={target_ratio:.0%} vel={velocity:.3f} roi={float(hot_profile.get('m
             route_pair_ins = getattr(self, '_cycle_route_pair_in_channels', set())
             if normalized in route_pair_ins:
                 score += 40
+
+            # Persistent source-channel reliability from rebalance history.
+            # This complements the in-memory recent-failure penalty below.
+            try:
+                source_signal = self._normalize_rebalance_success_signal(
+                    getattr(self.database, "get_source_rebalance_success_rate", lambda *_a, **_k: None)(
+                        cid, 30
+                    )
+                )
+                if source_signal is not None:
+                    reliability_delta = int(
+                        round((source_signal["rate"] - 0.5) * 160 * source_signal["confidence"])
+                    )
+                    score += reliability_delta
+            except Exception:
+                pass
 
             # RELIABILITY PENALTY: Penalize sources with recent failures
             fails = self.job_manager.get_source_failure_count(cid)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -117,6 +117,68 @@ class TestChannelRebalanceSuccessRate:
         assert result is None
 
 
+class TestPeerAndSourceRebalanceSuccessRate:
+    """Real SQLite tests for peer/source rebalance success aggregation."""
+
+    def _make_db(self, tmp_path):
+        db_path = os.path.join(tmp_path, "test_peer_source_sr.db")
+        plugin = MagicMock()
+        db = Database(db_path, plugin)
+        db.initialize()
+        return db
+
+    def test_peer_and_source_success_rates_use_existing_rebalance_history(self, tmp_path):
+        """Peer and source success rates should aggregate existing rebalance_history rows."""
+        db = self._make_db(tmp_path)
+        conn = db._get_connection()
+        now = int(time.time())
+        peer_id = "02" + "b" * 64
+
+        # Two destination channels for the same peer
+        conn.execute(
+            "INSERT INTO channel_states "
+            "(channel_id, peer_id, state, flow_ratio, sats_in, sats_out, capacity, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("111x1x0", peer_id, "balanced", 0.5, 0, 0, 1_000_000, now),
+        )
+        conn.execute(
+            "INSERT INTO channel_states "
+            "(channel_id, peer_id, state, flow_ratio, sats_in, sats_out, capacity, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("111x2x0", peer_id, "balanced", 0.5, 0, 0, 1_000_000, now),
+        )
+
+        rows = [
+            ("src-good", "111x1x0", 50_000, 100, 10, 50, "success", "normal", now - 3600),
+            ("src-good", "111x2x0", 50_000, 100, 10, 50, "success", "normal", now - 7200),
+            ("src-good", "111x2x0", 50_000, 100, None, 50, "failed", "normal", now - 10_800),
+            ("src-bad", "111x1x0", 50_000, 100, None, 50, "failed", "normal", now - 14_400),
+        ]
+        for row in rows:
+            conn.execute(
+                "INSERT INTO rebalance_history "
+                "(from_channel, to_channel, amount_sats, max_fee_sats, actual_fee_sats, "
+                "expected_profit_sats, status, rebalance_type, timestamp) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                row,
+            )
+        conn.commit()
+
+        peer_result = db.get_peer_rebalance_success_rate(peer_id, 30)
+        assert peer_result is not None
+        assert peer_result["total"] == 4
+        assert peer_result["successes"] == 2
+        assert peer_result["failures"] == 2
+        assert abs(peer_result["success_rate"] - 0.5) < 0.01
+
+        source_result = db.get_source_rebalance_success_rate("src-good", 30)
+        assert source_result is not None
+        assert source_result["total"] == 3
+        assert source_result["successes"] == 2
+        assert source_result["failures"] == 1
+        assert abs(source_result["success_rate"] - (2 / 3)) < 0.01
+
+
 # =============================================================================
 # Audit Round 8 – Turn 3 Regression Tests
 # =============================================================================

--- a/tests/test_rebalance_executor.py
+++ b/tests/test_rebalance_executor.py
@@ -561,6 +561,281 @@ class TestExecuteFailure:
         assert any(c[0][1]["inform"] == "failed" for c in inform_calls)
         assert any(c[0][1]["inform"] == "succeeded" for c in inform_calls)
 
+    def test_runtime_memory_excludes_banned_channel(self):
+        plugin = MagicMock()
+        plugin.rpc.getinfo.return_value = {"id": "our_id"}
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "hash123", "payment_secret": "secret123",
+            "bolt11": "lnbc5u1..."
+        }
+        plugin.rpc.listchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "300x1x0",
+                    "direction": 1,
+                    "base_fee_millisatoshi": 1000,
+                    "fee_per_millionth": 10,
+                    "delay": 18,
+                }
+            ]
+        }
+        plugin.rpc.listpeerchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "200x1x0",
+                    "updates": {
+                        "remote": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 0,
+                            "cltv_expiry_delta": 6,
+                        },
+                    },
+                }
+            ]
+        }
+        plugin.rpc.getroute.return_value = {
+            "route": [
+                {
+                    "id": "dest_peer_abc",
+                    "channel": "300x1x0",
+                    "direction": 1,
+                    "amount_msat": 500_000_000,
+                    "delay": 24,
+                },
+            ]
+        }
+        plugin.rpc.waitsendpay.return_value = {
+            "status": "complete",
+            "amount_sent_msat": 500_006_000,
+        }
+
+        executor = RebalanceExecutor(plugin, MagicMock(), MagicMock())
+        executor._routing_memory.ban_channel("940851x30x0/0", ttl_seconds=300)
+
+        result = executor.execute(MockCandidate(hive_route_hops=0))
+
+        assert result.success is True
+        assert plugin.rpc.getroute.call_args.kwargs["exclude"] == ["940851x30x0/0"]
+
+    def test_constraint_excludes_oversized_route_before_sendpay(self):
+        plugin = MagicMock()
+        plugin.rpc.getinfo.return_value = {"id": "our_id"}
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "hash123", "payment_secret": "secret123",
+            "bolt11": "lnbc5u1..."
+        }
+        plugin.rpc.listchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "300x1x0",
+                    "direction": 1,
+                    "base_fee_millisatoshi": 1000,
+                    "fee_per_millionth": 10,
+                    "delay": 18,
+                },
+                {
+                    "short_channel_id": "301x1x0",
+                    "direction": 0,
+                    "base_fee_millisatoshi": 1000,
+                    "fee_per_millionth": 10,
+                    "delay": 18,
+                },
+            ]
+        }
+        plugin.rpc.listpeerchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "200x1x0",
+                    "updates": {
+                        "remote": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 0,
+                            "cltv_expiry_delta": 6,
+                        },
+                    },
+                }
+            ]
+        }
+        plugin.rpc.getroute.side_effect = [
+            {
+                "route": [
+                    {
+                        "id": "dest_peer_abc",
+                        "channel": "300x1x0",
+                        "direction": 1,
+                        "amount_msat": 500_000_000,
+                        "delay": 24,
+                    },
+                ]
+            },
+            {
+                "route": [
+                    {
+                        "id": "dest_peer_abc",
+                        "channel": "301x1x0",
+                        "direction": 0,
+                        "amount_msat": 500_000_000,
+                        "delay": 24,
+                    },
+                ]
+            },
+        ]
+        plugin.rpc.waitsendpay.return_value = {
+            "status": "complete",
+            "amount_sent_msat": 500_006_000,
+        }
+
+        executor = RebalanceExecutor(plugin, MagicMock(), MagicMock())
+        executor._routing_memory.constrain_channel("300x1x0/1", 400_000_000, ttl_seconds=300)
+
+        result = executor.execute(MockCandidate(hive_route_hops=0))
+
+        assert result.success is True
+        assert plugin.rpc.getroute.call_count == 2
+        assert plugin.rpc.getroute.call_args_list[1].kwargs["exclude"] == ["300x1x0/1"]
+        plugin.rpc.sendpay.assert_called_once()
+
+    def test_temp_channel_failure_learns_ban(self):
+        plugin = MagicMock()
+        plugin.rpc.getinfo.return_value = {"id": "our_id"}
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "hash123", "payment_secret": "secret123",
+            "bolt11": "lnbc5u1..."
+        }
+        plugin.rpc.listchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "300x1x0",
+                    "direction": 1,
+                    "base_fee_millisatoshi": 1000,
+                    "fee_per_millionth": 10,
+                    "delay": 18,
+                },
+                {
+                    "short_channel_id": "301x1x0",
+                    "direction": 0,
+                    "base_fee_millisatoshi": 1000,
+                    "fee_per_millionth": 10,
+                    "delay": 18,
+                }
+            ]
+        }
+        plugin.rpc.listpeerchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "200x1x0",
+                    "updates": {
+                        "remote": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 0,
+                            "cltv_expiry_delta": 6,
+                        },
+                    },
+                }
+            ]
+        }
+        plugin.rpc.getroute.side_effect = [
+            {
+                "route": [
+                    {
+                        "id": "dest_peer_abc",
+                        "channel": "300x1x0",
+                        "direction": 1,
+                        "amount_msat": 500_000_000,
+                        "delay": 24,
+                    },
+                ]
+            },
+            {
+                "route": [
+                    {
+                        "id": "dest_peer_abc",
+                        "channel": "301x1x0",
+                        "direction": 0,
+                        "amount_msat": 500_000_000,
+                        "delay": 24,
+                    },
+                ]
+            },
+        ]
+        plugin.rpc.waitsendpay.side_effect = [
+            FakeRpcError(error={
+                "code": 204,
+                "message": "failed: WIRE_TEMPORARY_CHANNEL_FAILURE",
+                "data": {
+                    "erring_index": 2,
+                    "erring_channel": "940851x30x0",
+                    "erring_direction": 0,
+                    "failcode": 4103,
+                    "failcodename": "WIRE_TEMPORARY_CHANNEL_FAILURE",
+                },
+            }),
+            {
+                "status": "complete",
+                "amount_sent_msat": 500_006_000,
+            },
+        ]
+
+        executor = RebalanceExecutor(plugin, MagicMock(), MagicMock())
+        result = executor.execute(MockCandidate(hive_route_hops=0))
+
+        assert result.success is True
+        assert "940851x30x0/0" in executor._routing_memory.current_excludes()
+
+    def test_immediate_sendpay_failure_bans_first_hop(self):
+        plugin = MagicMock()
+        plugin.rpc.getinfo.return_value = {"id": "our_id"}
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "hash123", "payment_secret": "secret123",
+            "bolt11": "lnbc5u1..."
+        }
+        plugin.rpc.listchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "300x1x0",
+                    "direction": 1,
+                    "base_fee_millisatoshi": 1000,
+                    "fee_per_millionth": 10,
+                    "delay": 18,
+                }
+            ]
+        }
+        plugin.rpc.listpeerchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "200x1x0",
+                    "updates": {
+                        "remote": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 0,
+                            "cltv_expiry_delta": 6,
+                        },
+                    },
+                }
+            ]
+        }
+        plugin.rpc.getroute.return_value = {
+            "route": [
+                {
+                    "id": "dest_peer_abc",
+                    "channel": "300x1x0",
+                    "direction": 1,
+                    "amount_msat": 500_000_000,
+                    "delay": 24,
+                },
+            ]
+        }
+        plugin.rpc.sendpay.side_effect = FakeRpcError(
+            command="sendpay",
+            error={"code": 205, "message": "failed: PAY_TRY_OTHER_ROUTE"},
+        )
+
+        executor = RebalanceExecutor(plugin, MagicMock(), MagicMock())
+        result = executor.execute(MockCandidate(hive_route_hops=0))
+
+        assert result.success is False
+        assert "100x1x0/0" in executor._routing_memory.current_excludes()
+
     def test_execute_reserves_and_unreserves_capacity(self):
         plugin = MagicMock()
         plugin.rpc.getinfo.return_value = {"id": "our_id"}

--- a/tests/test_rebalance_executor.py
+++ b/tests/test_rebalance_executor.py
@@ -203,18 +203,11 @@ class TestExecuteSuccess:
         plugin.rpc.getroute.return_value = {
             "route": [
                 {
-                    "id": "mid_node",
-                    "channel": "200x1x0",
+                    "id": "dest_peer_abc",
+                    "channel": "300x1x0",
                     "direction": 1,
                     "amount_msat": 500_000_000,
-                    "delay": 18,
-                },
-                {
-                    "id": "our_id",
-                    "channel": "300x1x0",
-                    "direction": 0,
-                    "amount_msat": 499_982_000,
-                    "delay": 6,
+                    "delay": 24,
                 },
             ]
         }
@@ -229,13 +222,23 @@ class TestExecuteSuccess:
                             "cltv_expiry_delta": 6,
                         },
                     },
+                },
+                {
+                    "short_channel_id": "200x1x0",
+                    "updates": {
+                        "remote": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 0,
+                            "cltv_expiry_delta": 6,
+                        },
+                    },
                 }
             ]
         }
         plugin.rpc.listchannels.return_value = {
             "channels": [
                 {
-                    "short_channel_id": "200x1x0",
+                    "short_channel_id": "300x1x0",
                     "direction": 1,
                     "base_fee_millisatoshi": 1000,
                     "fee_per_millionth": 34,
@@ -253,47 +256,90 @@ class TestExecuteSuccess:
         result = executor.execute(candidate)
 
         assert result.success is True
+        plugin.rpc.getroute.assert_called_once_with(
+            "dest_peer_abc",
+            500_000_000,
+            24,
+            fromid="source_peer_abc",
+            maxhops=6,
+            fuzzpercent=0,
+        )
         sendpay_route = plugin.rpc.sendpay.call_args.kwargs["route"]
         assert sendpay_route[0]["channel"] == "100x1x0"
         assert sendpay_route[0]["amount_msat"] == 500_018_000
-        assert sendpay_route[0]["delay"] == 52
+        assert sendpay_route[0]["delay"] == 58
+        assert sendpay_route[-1]["channel"] == "200x1x0"
+        assert sendpay_route[-1]["amount_msat"] == 500_000_000
 
-    def test_fleet_route_uses_getroutes_execution_path(self):
+    def test_fleet_execution_does_not_use_getroutes_for_sendpay(self):
         plugin = MagicMock()
         plugin.rpc.getinfo.return_value = {"id": "our_id"}
         plugin.rpc.invoice.return_value = {
             "payment_hash": "hash123", "payment_secret": "secret123",
             "bolt11": "lnbc5u1..."
         }
-        plugin.rpc.listpeerchannels.return_value = {"channels": []}
+        plugin.rpc.listpeerchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "100x1x0",
+                    "updates": {
+                        "local": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 10,
+                            "cltv_expiry_delta": 6,
+                        },
+                        "remote": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 0,
+                            "cltv_expiry_delta": 6,
+                        },
+                    },
+                },
+                {
+                    "short_channel_id": "200x1x0",
+                    "updates": {
+                        "remote": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 10,
+                            "cltv_expiry_delta": 6,
+                        },
+                    },
+                },
+            ]
+        }
+        plugin.rpc.listchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "300x1x0",
+                    "direction": 0,
+                    "base_fee_millisatoshi": 1000,
+                    "fee_per_millionth": 10,
+                    "delay": 18,
+                }
+            ]
+        }
+        plugin.rpc.getroute.return_value = {
+            "route": [
+                {
+                    "id": "dest_peer_abc",
+                    "channel": "300x1x0",
+                    "direction": 0,
+                    "amount_msat": 500_005_000,
+                    "delay": 24,
+                },
+            ]
+        }
         plugin.rpc.waitsendpay.return_value = {
-            "status": "complete", "amount_sent_msat": 500_000_000
+            "status": "complete", "amount_sent_msat": 500_011_000
         }
 
         def call_side_effect(method, params=None):
             if method == "askrene-listlayers":
                 return {"layers": [{"layer": "hive-fleet"}, {"layer": "revenue-local"}]}
             if method == "getroutes":
-                return {
-                    "routes": [{
-                        "amount_msat": 500_000_000,
-                        "path": [
-                            {
-                                "short_channel_id_dir": "100x1x0/1",
-                                "next_node_id": "fleet_mid",
-                                "amount_msat": 500_000_000,
-                                "delay": 24,
-                            },
-                            {
-                                "short_channel_id_dir": "300x1x0/0",
-                                "next_node_id": "dest_peer_abc",
-                                "amount_msat": 500_000_000,
-                                "delay": 18,
-                            },
-                        ],
-                    }],
-                    "probability_ppm": 999999,
-                }
+                raise AssertionError("direct getroutes execution path should not be used")
+            if method == "askrene-inform-channel":
+                return {}
             return {}
 
         plugin.rpc.call.side_effect = call_side_effect
@@ -304,18 +350,78 @@ class TestExecuteSuccess:
         result = executor.execute(candidate)
 
         assert result.success is True
-        plugin.rpc.getroute.assert_not_called()
-        plugin.rpc.call.assert_any_call("getroutes", {
-            "source": "our_id",
-            "destination": "dest_peer_abc",
+        plugin.rpc.getroute.assert_called_once_with(
+            "dest_peer_abc",
+            500_005_000,
+            24,
+            fromid="source_peer_abc",
+            maxhops=6,
+            fuzzpercent=0,
+        )
+        sendpay_route = plugin.rpc.sendpay.call_args.kwargs["route"]
+        assert sendpay_route[-1] == {
+            "channel": "200x1x0",
+            "id": "our_id",
             "amount_msat": 500_000_000,
-            "layers": ["auto.localchans", "hive-fleet", "revenue-local"],
-            "maxfee_msat": 100_000,
-            "final_cltv": 18,
-        })
+            "delay": 18,
+            "style": "tlv",
+        }
 
 
 class TestExecuteFailure:
+    def test_rejects_malformed_route_before_sendpay(self):
+        plugin = MagicMock()
+        plugin.rpc.getinfo.return_value = {"id": "our_id"}
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "hash123", "payment_secret": "secret123",
+            "bolt11": "lnbc5u1..."
+        }
+        plugin.rpc.listpeerchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "100x1x0",
+                    "updates": {"local": {"cltv_expiry_delta": 6}},
+                },
+                {
+                    "short_channel_id": "200x1x0",
+                    "updates": {"remote": {"cltv_expiry_delta": 6}},
+                },
+            ]
+        }
+        plugin.rpc.listchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "300x1x0",
+                    "direction": 0,
+                    "base_fee_millisatoshi": 0,
+                    "fee_per_millionth": 0,
+                    "delay": 18,
+                }
+            ]
+        }
+        plugin.rpc.getroute.return_value = {
+            "route": [
+                {
+                    "id": "dest_peer_abc",
+                    "channel": "300x1x0",
+                    "direction": 0,
+                    "amount_msat": 400_000_000,
+                    "delay": 24,
+                },
+            ]
+        }
+        plugin.rpc.waitsendpay.return_value = {
+            "status": "complete",
+            "amount_sent_msat": 400_000_000,
+        }
+
+        executor = RebalanceExecutor(plugin, MagicMock(), MagicMock())
+        result = executor.execute(MockCandidate(hive_route_hops=0))
+
+        assert result.success is False
+        assert result.error == "sendpay_error: increasing_route_amount"
+        plugin.rpc.sendpay.assert_not_called()
+
     def test_no_routes(self):
         plugin = MagicMock()
         plugin.rpc.getinfo.return_value = {"id": "our_id"}
@@ -367,49 +473,55 @@ class TestExecuteFailure:
         plugin.rpc.listchannels.return_value = {
             "channels": [
                 {
-                    "short_channel_id": "200x1x0",
+                    "short_channel_id": "300x1x0",
                     "direction": 1,
+                    "base_fee_millisatoshi": 1000,
+                    "fee_per_millionth": 10,
+                    "delay": 18,
+                },
+                {
+                    "short_channel_id": "301x1x0",
+                    "direction": 0,
                     "base_fee_millisatoshi": 1000,
                     "fee_per_millionth": 10,
                     "delay": 18,
                 }
             ]
         }
-        plugin.rpc.listpeerchannels.return_value = {"channels": []}
+        plugin.rpc.listpeerchannels.return_value = {
+            "channels": [
+                {
+                    "short_channel_id": "200x1x0",
+                    "updates": {
+                        "remote": {
+                            "fee_base_msat": 0,
+                            "fee_proportional_millionths": 0,
+                            "cltv_expiry_delta": 6,
+                        },
+                    },
+                }
+            ]
+        }
         plugin.rpc.getroute.side_effect = [
             {
                 "route": [
                     {
-                        "id": "mid_a",
-                        "channel": "200x1x0",
+                        "id": "dest_peer_abc",
+                        "channel": "300x1x0",
                         "direction": 1,
                         "amount_msat": 500_000_000,
                         "delay": 24,
-                    },
-                    {
-                        "id": "our_id",
-                        "channel": "300x1x0",
-                        "direction": 0,
-                        "amount_msat": 499_990_000,
-                        "delay": 6,
                     },
                 ]
             },
             {
                 "route": [
                     {
-                        "id": "mid_b",
-                        "channel": "201x1x0",
+                        "id": "dest_peer_abc",
+                        "channel": "301x1x0",
                         "direction": 0,
                         "amount_msat": 500_000_000,
                         "delay": 24,
-                    },
-                    {
-                        "id": "our_id",
-                        "channel": "300x1x0",
-                        "direction": 0,
-                        "amount_msat": 499_990_000,
-                        "delay": 6,
                     },
                 ]
             },

--- a/tests/test_rebalance_memory.py
+++ b/tests/test_rebalance_memory.py
@@ -1,0 +1,22 @@
+"""Tests for rebalance routing memory."""
+
+from modules.rebalance_memory import RebalanceRoutingMemory
+
+
+def test_channel_and_node_bans_expire():
+    memory = RebalanceRoutingMemory()
+
+    memory.ban_channel("100x1x0/1", ttl_seconds=60, now=1000.0)
+    memory.ban_node("node_abc", ttl_seconds=60, now=1000.0)
+
+    assert sorted(memory.current_excludes(now=1020.0)) == ["100x1x0/1", "node_abc"]
+    assert memory.current_excludes(now=1061.0) == []
+
+
+def test_constraints_expire_and_return_max_amount():
+    memory = RebalanceRoutingMemory()
+
+    memory.constrain_channel("100x1x0/1", 123_456, ttl_seconds=60, now=1000.0)
+
+    assert memory.max_amount_for("100x1x0/1", now=1001.0) == 123_456
+    assert memory.max_amount_for("100x1x0/1", now=1061.0) is None

--- a/tests/test_rebalancer_audit_regressions.py
+++ b/tests/test_rebalancer_audit_regressions.py
@@ -618,6 +618,161 @@ class TestB2WeeklyBudgetExtCosts:
 
 
 # ============================================================================
+# 7. Rebalance-specific reliability should leverage rebalance history
+# ============================================================================
+
+
+class TestRebalanceReliabilityIntegration:
+    """Rebalance routing should prefer rebalance-specific success signals."""
+
+    def _make_rebalancer(self, mock_plugin, mock_database):
+        from modules.config import Config
+        from modules.rebalancer import EVRebalancer
+
+        cfg = Config(
+            dry_run=True,
+            enable_proportional_budget=False,
+            enable_kelly=False,
+            enable_velocity_gate=False,
+            rebalance_min_amount=50_000,
+            rebalance_max_amount=5_000_000,
+            rebalance_min_profit=0,
+            rebalance_min_profit_ppm=0,
+            rebalance_cooldown_hours=24,
+            flow_window_days=7,
+            hot_channel_protection_enabled=False,
+        )
+        r = EVRebalancer(mock_plugin, cfg, mock_database)
+        r._profitability_analyzer = None
+        return r
+
+    def test_source_selection_prefers_persistently_successful_source(self, mock_plugin, mock_database):
+        """Persistent source-channel success should break ties before transient retries do."""
+        r = self._make_rebalancer(mock_plugin, mock_database)
+
+        bad_peer_id = "02" + "c" * 64
+        good_peer_id = "02" + "d" * 64
+        sources = [
+            ("111x1x0", {"peer_id": bad_peer_id, "capacity": 5_000_000, "spendable_sats": 4_000_000, "fee_ppm": 50}, 0.9),
+            ("111x2x0", {"peer_id": good_peer_id, "capacity": 5_000_000, "spendable_sats": 4_000_000, "fee_ppm": 50}, 0.9),
+        ]
+
+        mock_database.get_channel_state.return_value = {"state": "balanced"}
+        mock_database.get_peer_uptime_percent.return_value = 100.0
+        mock_database.get_source_rebalance_success_rate.side_effect = lambda cid, window_days=30: {
+            "111x1x0": {"total": 12, "successes": 2, "failures": 10, "success_rate": 2 / 12},
+            "111x2x0": {"total": 12, "successes": 10, "failures": 2, "success_rate": 10 / 12},
+        }.get(cid)
+
+        selected = r._select_source_candidates(
+            sources=sources,
+            amount_needed=50_000,
+            dest_channel="222x333x0",
+            dest_outbound_fee_ppm=1200,
+            dest_inbound_fee_ppm=100,
+            peer_status={
+                bad_peer_id: {"connected": True},
+                good_peer_id: {"connected": True},
+            },
+        )
+
+        assert selected, "Expected at least one source candidate"
+        assert selected[0][0] == "111x2x0", (
+            "Persistent rebalance success should prefer 111x2x0 over 111x1x0 "
+            "when other source attributes are equal."
+        )
+
+    def test_ev_profit_is_discounted_by_rebalance_success_history(self, mock_plugin, mock_database):
+        """Identical generic peer reputation should still diverge on rebalance-specific history."""
+        r = self._make_rebalancer(mock_plugin, mock_database)
+
+        dest_channel = "222x333x0"
+        dest_peer_id = "02" + "b" * 64
+        source_scid = "333x444x0"
+        source_peer_id = "02" + "c" * 64
+
+        dest_info = {
+            "peer_id": dest_peer_id,
+            "capacity": 10_000_000,
+            "spendable_sats": 500_000,
+            "fee_ppm": 5000,
+        }
+        source_info = {
+            "peer_id": source_peer_id,
+            "capacity": 10_000_000,
+            "spendable_sats": 4_000_000,
+            "fee_ppm": 25,
+        }
+        sources = [(source_scid, source_info, 0.8)]
+
+        mock_database.get_channel_state.return_value = {
+            "state": "balanced",
+            "sats_in": 10_000,
+            "sats_out": 10_000,
+        }
+        mock_database.get_fee_strategy_state.return_value = {"last_broadcast_fee_ppm": 5000}
+        mock_database.get_peer_uptime_percent.return_value = 100.0
+        mock_database.get_failure_count.return_value = (0, None)
+        mock_database.get_failure_metadata.return_value = {"last_attempted_ppm": 0}
+        mock_database.get_kalman_state.return_value = None
+        mock_database.get_historical_inbound_fee_ppm.return_value = None
+        mock_database.get_peer_closed_channel_profit_summary.return_value = None
+        mock_database.list_hot_channel_protection_override_peers.return_value = []
+        mock_database.get_peer_reputation.return_value = {
+            "successes": 0,
+            "failures": 0,
+            "score": 0.5,
+        }
+
+        r._estimate_inbound_fee = MagicMock(return_value=10)
+        r._get_channel_age_days = MagicMock(return_value=30)
+        r._select_source_candidates = MagicMock(return_value=[
+            (source_scid, source_info, 1.0, 50),
+        ])
+
+        mock_database.get_peer_rebalance_success_rate.return_value = {
+            "total": 10, "successes": 9, "failures": 1, "success_rate": 0.9,
+        }
+        mock_database.get_channel_rebalance_success_rate.return_value = {
+            "total": 10, "successes": 9, "failures": 1, "success_rate": 0.9,
+            "avg_cost_ppm": 10, "avg_amount_sats": 50_000,
+        }
+        mock_database.get_source_rebalance_success_rate.return_value = {
+            "total": 10, "successes": 9, "failures": 1, "success_rate": 0.9,
+        }
+        high = r._analyze_rebalance_ev(
+            dest_channel=dest_channel,
+            dest_info=dest_info,
+            dest_ratio=0.05,
+            sources=sources,
+        )
+
+        mock_database.get_peer_rebalance_success_rate.return_value = {
+            "total": 10, "successes": 1, "failures": 9, "success_rate": 0.1,
+        }
+        mock_database.get_channel_rebalance_success_rate.return_value = {
+            "total": 10, "successes": 1, "failures": 9, "success_rate": 0.1,
+            "avg_cost_ppm": 10, "avg_amount_sats": 50_000,
+        }
+        mock_database.get_source_rebalance_success_rate.return_value = {
+            "total": 10, "successes": 1, "failures": 9, "success_rate": 0.1,
+        }
+        low = r._analyze_rebalance_ev(
+            dest_channel=dest_channel,
+            dest_info=dest_info,
+            dest_ratio=0.05,
+            sources=sources,
+        )
+
+        assert high is not None
+        assert low is not None
+        assert high.expected_profit_sats > low.expected_profit_sats, (
+            "Rebalance-specific success history should affect EV independently "
+            "of generic forwarding reputation."
+        )
+
+
+# ============================================================================
 # 7. B3: Push EV uses wrong peer for fee estimation
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- replace live fleet  execution with the safe explicit single-path rebalance executor and add transient routing memory for bans and amount constraints
- add retry and askrene-feedback plumbing around native sendpay execution so rebalance failures inform future route selection without relying on Sling
- incorporate rebalance-history-based peer and source reliability into rebalancer scoring and EV, separate from generic forwarding peer reputation

## Test Plan
- [x] ........................................................................ [ 43%]
........................................................................ [ 87%]
.....................                                                    [100%]
165 passed in 0.59s
