### PR TITLE
fix: use peer_id= not id= for listpeerchannels calls in v2 router

### DIFF
--- a/modules/rebalance_router_v2.py
+++ b/modules/rebalance_router_v2.py
@@ -63,7 +63,7 @@ class RebalanceRouter:
         """
         # --- Priority 1: listpeerchannels filtered by peer ---
         try:
-            result = self.plugin.rpc.listpeerchannels(id=dest_peer_id)
+            result = self.plugin.rpc.listpeerchannels(peer_id=dest_peer_id)
             for ch in result.get("channels", []):
                 if ch.get("peer_id") != dest_peer_id:
                     continue
@@ -120,7 +120,7 @@ class RebalanceRouter:
     def _get_source_channel_policy(self, source_peer_id: str) -> Dict[str, Any]:
         """Get our outbound fee/cltv for the source channel from peer's perspective."""
         try:
-            result = self.plugin.rpc.listpeerchannels(id=source_peer_id)
+            result = self.plugin.rpc.listpeerchannels(peer_id=source_peer_id)
             for ch in result.get("channels", []):
                 updates = ch.get("updates") or {}
                 local = updates.get("local") or {}
@@ -136,7 +136,7 @@ class RebalanceRouter:
     def _get_dest_channel_cltv(self, dest_peer_id: str) -> int:
         """Get the dest peer's cltv_expiry_delta for the final hop."""
         try:
-            result = self.plugin.rpc.listpeerchannels(id=dest_peer_id)
+            result = self.plugin.rpc.listpeerchannels(peer_id=dest_peer_id)
             for ch in result.get("channels", []):
                 updates = ch.get("updates") or {}
                 remote = updates.get("remote") or {}

--- a/tests/test_rebalance_router_v2.py
+++ b/tests/test_rebalance_router_v2.py
@@ -29,10 +29,15 @@ def _make_plugin(
     """
     plugin = MagicMock()
 
-    def _listpeerchannels(**kwargs):
+    def _listpeerchannels(peer_id=None, short_channel_id=None):
+        """Matches pyln.client.LightningRpc.listpeerchannels signature.
+
+        Regression guard: if router code passes ``id=`` instead of
+        ``peer_id=`` (as the real pyln-client expects), this mock raises
+        TypeError just like the real RPC layer would on the live node.
+        """
         if listpeerchannels_error:
             raise listpeerchannels_error
-        peer_id = kwargs.get("id")
         if peer_channels_by_id and peer_id in peer_channels_by_id:
             return peer_channels_by_id[peer_id]
         return {"channels": []}
@@ -83,7 +88,7 @@ def _source_peer_channels(fee_ppm=0, cltv=18):
 
 class TestFinalHopFeeFromListpeerchannels:
     def test_router_gets_actual_final_hop_fee_from_listpeerchannels(self):
-        """Uses listpeerchannels(id=dest_peer_id) for fee lookup."""
+        """Uses listpeerchannels(peer_id=dest_peer_id) for fee lookup."""
         middle_route = [{
             "id": DEST_PEER,
             "channel": "300x1x0",
@@ -105,11 +110,42 @@ class TestFinalHopFeeFromListpeerchannels:
 
         assert result.success is True
         assert result.final_hop_fee_ppm == 275
-        # listpeerchannels called with id= filter (not unfiltered)
+        # listpeerchannels called with peer_id= filter (not unfiltered).
+        # Regression guard: pyln.client.LightningRpc.listpeerchannels
+        # accepts peer_id=, not id=. See the _make_plugin helper for the
+        # enforced signature.
         calls = plugin.rpc.listpeerchannels.call_args_list
-        dest_call = [c for c in calls if c.kwargs.get("id") == DEST_PEER]
+        dest_call = [c for c in calls if c.kwargs.get("peer_id") == DEST_PEER]
         assert len(dest_call) >= 1
         plugin.rpc.listchannels.assert_not_called()
+
+    def test_router_does_not_call_listpeerchannels_with_legacy_id_kwarg(self):
+        """Regression test: earlier versions passed id= which raised
+        TypeError on pyln.client.LightningRpc.listpeerchannels. Live nexus-01
+        surfaced the bug silently because the listchannels fallback caught it."""
+        plugin = _make_plugin(
+            peer_channels_by_id={
+                DEST_PEER: _dest_peer_channels(fee_ppm=275),
+                SOURCE_PEER: _source_peer_channels(),
+            },
+            getroute={"route": [{
+                "id": DEST_PEER,
+                "channel": "300x1x0",
+                "amount_msat": 50_014_000,
+                "delay": 40,
+            }]},
+        )
+        router = RebalanceRouter(plugin, OUR_ID)
+        router.price_pair(
+            SOURCE_SCID, DEST_SCID, SOURCE_PEER, DEST_PEER, AMOUNT_SATS
+        )
+
+        # Every listpeerchannels call must use the real pyln-client keyword
+        # (peer_id=), never the buggy id=.
+        for c in plugin.rpc.listpeerchannels.call_args_list:
+            assert "id" not in c.kwargs, (
+                f"listpeerchannels called with legacy id= kwarg: {c.kwargs}"
+            )
 
 
 class TestFallbackToListchannels:


### PR DESCRIPTION
pyln.client.LightningRpc.listpeerchannels(peer_id, short_channel_id) accepts 'peer_id' as a keyword argument, not 'id'. Three call sites in modules/rebalance_router_v2.py were passing id= which raised "TypeError: unexpected keyword argument 'id'" at runtime, silently caught by the Priority 2 listchannels fallback path.

Surfaced during Phase 1 smoke-test of the v3 router on nexus-01 (Python 3.13.3 + current pyln-client): every pair pricing logged '[router-v2] listpeerchannels lookup failed for <peer>:
  LightningRpc.listpeerchannels() got an unexpected keyword argument
  "id"' at debug level. Rebalancing continued to work because the
listchannels fallback succeeded, but every pricing paid one wasted RPC round-trip + exception.

Fix:
- modules/rebalance_router_v2.py: three call sites changed to peer_id=
- tests/test_rebalance_router_v2.py: _make_plugin's mock signature now enforces the real pyln-client signature (peer_id, short_channel_id), so any future regression will raise TypeError in tests
- new regression test test_router_does_not_call_listpeerchannels_with_legacy_id_kwarg explicitly asserts no 'id' kwarg appears in any listpeerchannels call

8 v2 router tests pass (7 existing + 1 new regression guard). Full suite: 1350 passing, only the pre-existing test_hive_live_contract failure remains.