### PR TITLE
feat: add pair-level futility tracker to rebalance engine v2

### DIFF
--- a/modules/rebalance_audit_v2.py
+++ b/modules/rebalance_audit_v2.py
@@ -4,15 +4,29 @@ Every cycle must explain itself. For every valuable channel the engine
 evaluates, one of the ``log_*`` helpers emits a deterministic, grep-friendly
 record that replaces the vague ad-hoc messages of the v1 engine.
 
-Tag vocabulary (``reason`` field in REBAL_SKIP):
-    selected, skipped_inside_band, skipped_not_valuable, skipped_no_partner,
-    skipped_no_budget, skipped_no_route, skipped_route_over_budget,
-    skipped_cooldown, skipped_policy
+Canonical skip reasons live in ``VALID_SKIP_REASONS``.
 """
 
 from __future__ import annotations
 
 from typing import Any, Optional
+
+
+VALID_SKIP_REASONS: frozenset[str] = frozenset({
+    # Produced by the planner
+    "inside_band",
+    "not_valuable",
+    "no_partner",
+    "cooldown",
+    "no_budget",
+    "max_pairs_reached",
+    "outcompeted",
+    # Produced by the router / engine
+    "no_route",
+    "route_over_budget",
+    # Produced by the engine's pair-level futility tracker
+    "pair_futility",
+})
 
 
 class RebalanceAudit:

--- a/modules/rebalance_engine_v2.py
+++ b/modules/rebalance_engine_v2.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError, as_completed
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from .rebalance_audit_v2 import RebalanceAudit
 from .rebalance_executor_v2 import RebalanceExecutor, ExecutionResult
@@ -54,6 +54,16 @@ class RebalanceEngine:
         self._pool = ThreadPoolExecutor(
             max_workers=3, thread_name_prefix="rebal-v2"
         )
+        # Pair-level futility tracker: {(src_scid, dst_scid): [failure_ts, ...]}.
+        # A pair that fails _futility_threshold times within _futility_window_sec
+        # is skipped from subsequent cycles until the stale entries decay out
+        # of the window. Prevents re-picking the same unroutable pair every
+        # cycle (the old JobManager futility breaker was stubbed during the
+        # cleanup refactor; this replaces it at the engine level so it covers
+        # both v2 and v3 routers).
+        self._pair_failures: Dict[Tuple[str, str], List[float]] = {}
+        self._futility_threshold: int = 3
+        self._futility_window_sec: float = 1800.0  # 30 minutes
 
     def shutdown(self) -> None:
         """Release thread pool resources."""
@@ -254,6 +264,35 @@ class RebalanceEngine:
 
         return plan.selected
 
+    def _prune_pair_failures(self, key: Tuple[str, str]) -> List[float]:
+        """Drop failure timestamps older than the futility window and return survivors."""
+        timestamps = self._pair_failures.get(key, [])
+        if not timestamps:
+            return timestamps
+        cutoff = time.time() - self._futility_window_sec
+        fresh = [t for t in timestamps if t >= cutoff]
+        if len(fresh) != len(timestamps):
+            if fresh:
+                self._pair_failures[key] = fresh
+            else:
+                self._pair_failures.pop(key, None)
+        return fresh
+
+    def _is_pair_in_futility(self, source_channel_id: str, dest_channel_id: str) -> bool:
+        """Return True if this pair has hit the failure threshold in the window."""
+        key = (source_channel_id, dest_channel_id)
+        fresh = self._prune_pair_failures(key)
+        return len(fresh) >= self._futility_threshold
+
+    def _record_pair_failure(self, source_channel_id: str, dest_channel_id: str) -> None:
+        """Record an execution failure for this pair at the current time."""
+        key = (source_channel_id, dest_channel_id)
+        self._pair_failures.setdefault(key, []).append(time.time())
+
+    def _record_pair_success(self, source_channel_id: str, dest_channel_id: str) -> None:
+        """Clear any failure history for this pair (success resets the counter)."""
+        self._pair_failures.pop((source_channel_id, dest_channel_id), None)
+
     def _execute_pair(
         self,
         pair: PairCandidate,
@@ -286,7 +325,11 @@ class RebalanceEngine:
         return exec_result
 
     def run_cycle(self) -> CycleResult:
-        """Live execution: find candidates (already priced), execute concurrently."""
+        """Live execution: find candidates (already priced), execute concurrently.
+
+        Filters out pairs in futility state before submitting to the executor,
+        and records success/failure in the pair tracker for the next cycle.
+        """
         result = CycleResult()
 
         candidates = self.find_candidates()
@@ -295,11 +338,35 @@ class RebalanceEngine:
         if not candidates:
             return result
 
+        # Pair-level futility filter: skip pairs that failed too many times in
+        # the recent window. Emits a pair_futility audit record so the skip is
+        # visible in the REBAL_SKIP stream.
+        live_candidates: List[PairCandidate] = []
+        for pair in candidates:
+            if self._is_pair_in_futility(pair.source_channel_id, pair.dest_channel_id):
+                fresh = self._pair_failures.get(
+                    (pair.source_channel_id, pair.dest_channel_id), []
+                )
+                self._audit.log_skip(
+                    channel_id=pair.dest_channel_id,
+                    reason="pair_futility",
+                    value_class="valuable",
+                    detail=(
+                        f"src={pair.source_channel_id} "
+                        f"failures={len(fresh)} in window {int(self._futility_window_sec)}s"
+                    ),
+                )
+                continue
+            live_candidates.append(pair)
+
+        if not live_candidates:
+            return result
+
         executor = RebalanceExecutor(self.plugin, self.database)
 
-        # Submit all candidates to the thread pool
+        # Submit the surviving candidates to the thread pool
         futures: Dict[Future, PairCandidate] = {}
-        for pair in candidates:
+        for pair in live_candidates:
             future = self._pool.submit(self._execute_pair, pair, executor)
             futures[future] = pair
 
@@ -311,7 +378,23 @@ class RebalanceEngine:
                     exec_result = future.result()
                     if exec_result is not None:
                         result.executions.append(exec_result)
+                        if exec_result.success:
+                            self._record_pair_success(
+                                pair.source_channel_id, pair.dest_channel_id
+                            )
+                        else:
+                            self._record_pair_failure(
+                                pair.source_channel_id, pair.dest_channel_id
+                            )
+                    else:
+                        # _execute_pair returned None (no route stored on the pair) — count as failure
+                        self._record_pair_failure(
+                            pair.source_channel_id, pair.dest_channel_id
+                        )
                 except Exception as e:
+                    self._record_pair_failure(
+                        pair.source_channel_id, pair.dest_channel_id
+                    )
                     self._log(
                         f"Execution thread failed for "
                         f"{pair.source_channel_id}->{pair.dest_channel_id}: {e}",

--- a/tests/test_pair_futility.py
+++ b/tests/test_pair_futility.py
@@ -1,0 +1,112 @@
+"""Tests for the pair-level futility tracker in rebalance_engine_v2.
+
+A pair that fails execution N times within the futility window should be
+skipped from future cycles (with a `pair_futility` audit skip reason)
+until the failure timestamps decay out of the window.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+
+def _make_engine(futility_threshold=3, futility_window_sec=1800):
+    """Minimal RebalanceEngine for futility-tracker tests."""
+    from modules.rebalance_engine_v2 import RebalanceEngine
+
+    plugin = MagicMock()
+    plugin.rpc.call.side_effect = Exception("askrene unavailable")
+    plugin.rpc.getinfo.return_value = {"id": "03" + "u" * 64}
+
+    config = MagicMock()
+    config.rebalance_router = "v2"
+    config.askrene_layers = "hive-fleet"
+    del config.snapshot
+
+    database = MagicMock()
+    engine = RebalanceEngine(plugin=plugin, config=config, database=database)
+    # Override thresholds for deterministic tests
+    engine._futility_threshold = futility_threshold
+    engine._futility_window_sec = futility_window_sec
+    return engine
+
+
+def test_engine_tracks_pair_failures_in_dict():
+    engine = _make_engine()
+    assert hasattr(engine, "_pair_failures")
+    assert isinstance(engine._pair_failures, dict)
+    assert engine._pair_failures == {}
+
+
+def test_record_pair_failure_increments_counter():
+    engine = _make_engine()
+    engine._record_pair_failure("100x1x0", "200x2x0")
+    assert ("100x1x0", "200x2x0") in engine._pair_failures
+    assert len(engine._pair_failures[("100x1x0", "200x2x0")]) == 1
+
+    engine._record_pair_failure("100x1x0", "200x2x0")
+    assert len(engine._pair_failures[("100x1x0", "200x2x0")]) == 2
+
+
+def test_pair_not_in_futility_below_threshold():
+    engine = _make_engine(futility_threshold=3)
+    engine._record_pair_failure("100x1x0", "200x2x0")
+    engine._record_pair_failure("100x1x0", "200x2x0")
+    assert engine._is_pair_in_futility("100x1x0", "200x2x0") is False
+
+
+def test_pair_in_futility_at_threshold():
+    engine = _make_engine(futility_threshold=3)
+    for _ in range(3):
+        engine._record_pair_failure("100x1x0", "200x2x0")
+    assert engine._is_pair_in_futility("100x1x0", "200x2x0") is True
+
+
+def test_pair_futility_decays_after_window():
+    engine = _make_engine(futility_threshold=3, futility_window_sec=10)
+    # Manually inject old failures (11 seconds old — beyond window)
+    old_ts = time.time() - 11
+    engine._pair_failures[("100x1x0", "200x2x0")] = [old_ts, old_ts, old_ts]
+    # Should NOT be in futility because all failures are stale
+    assert engine._is_pair_in_futility("100x1x0", "200x2x0") is False
+    # And the stale entries should have been pruned
+    assert engine._pair_failures.get(("100x1x0", "200x2x0"), []) == []
+
+
+def test_pair_futility_mixed_old_and_new():
+    engine = _make_engine(futility_threshold=3, futility_window_sec=10)
+    old_ts = time.time() - 11
+    fresh_ts = time.time()
+    engine._pair_failures[("100x1x0", "200x2x0")] = [
+        old_ts, old_ts, fresh_ts, fresh_ts,
+    ]
+    # Only 2 fresh failures — below threshold of 3
+    assert engine._is_pair_in_futility("100x1x0", "200x2x0") is False
+    # Old entries pruned
+    assert len(engine._pair_failures[("100x1x0", "200x2x0")]) == 2
+
+
+def test_record_pair_success_clears_failure_history():
+    engine = _make_engine()
+    engine._record_pair_failure("100x1x0", "200x2x0")
+    engine._record_pair_failure("100x1x0", "200x2x0")
+    assert ("100x1x0", "200x2x0") in engine._pair_failures
+
+    engine._record_pair_success("100x1x0", "200x2x0")
+    assert ("100x1x0", "200x2x0") not in engine._pair_failures
+
+
+def test_pair_futility_is_directional():
+    """(A, B) and (B, A) are tracked as separate pairs."""
+    engine = _make_engine(futility_threshold=2)
+    engine._record_pair_failure("100x1x0", "200x2x0")
+    engine._record_pair_failure("100x1x0", "200x2x0")
+
+    # Forward direction is in futility
+    assert engine._is_pair_in_futility("100x1x0", "200x2x0") is True
+    # Reverse direction is NOT in futility — they're different pairs
+    assert engine._is_pair_in_futility("200x2x0", "100x1x0") is False
+
+
+def test_pair_futility_skip_reason_in_valid_set():
+    from modules.rebalance_audit_v2 import VALID_SKIP_REASONS
+    assert "pair_futility" in VALID_SKIP_REASONS


### PR DESCRIPTION
The v1 JobManager had a 'futility circuit breaker (10 failures → stop)' that was stubbed out during the Phase 1 cleanup refactor. Without it, the v2 engine has no memory of execution failures between cycles and keeps re-picking the same unroutable pair every 15 minutes.

Observed on nexus-01 (AzagGoats, node 0382d558) on 2026-04-10: the pair 932263x1883x0 → 939858x2330x0 at ~1.4M sats / 225 sats fee was selected by the planner at 17:17:19 and again at 17:26:51, with both execution attempts failing with '[ExecutorV2] Failed:  erring_channel=None'. The second attempt happened 9 min after the first because the engine had no memory of the first failure.

Fix: add an in-memory pair-level futility tracker to RebalanceEngine.

- self._pair_failures: {(src_scid, dst_scid): [failure_ts, ...]}
- self._futility_threshold = 3 failures
- self._futility_window_sec = 1800s (30 min)
- New helpers: _is_pair_in_futility, _record_pair_failure, _record_pair_success, _prune_pair_failures
- run_cycle filters candidates through _is_pair_in_futility before submitting to the executor and emits a pair_futility skip record via the audit logger for each filtered pair
- After execution, success clears the pair's counter and failure appends a new timestamp

Also introduces VALID_SKIP_REASONS in rebalance_audit_v2 (was previously undocumented) with the canonical set of v2 reasons + the new pair_futility entry. This makes the valid-reason vocabulary explicit and enables test-time validation.

9 new tests in tests/test_pair_futility.py cover: state init, increment, threshold check, decay, mixed old+new, success clearing, directionality, and VALID_SKIP_REASONS membership.

Full suite: 1359 passing, same pre-existing test_hive_live_contract failure (unrelated).