### PR TITLE
feat: probability-aware pair-budget relaxation

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -142,6 +142,7 @@ CONFIG_FIELD_TYPES: Dict[str, type] = {
     'capex_bootstrap_bps': int,
     'capex_bootstrap_max_sats': int,
     'capex_grace_days': int,
+    'capex_probability_budget_bonus': float,
     'capex_exploration_rate': float,
     'capex_tactical_rate': float,
     'capex_global_envelope_sats': int,
@@ -236,6 +237,7 @@ CONFIG_FIELD_RANGES: Dict[str, tuple] = {
     'capex_grace_days': (0, 90),
     'capex_exploration_rate': (0.0, 1.0),
     'capex_tactical_rate': (0.0, 1.0),
+    'capex_probability_budget_bonus': (0.0, 1.0),
     'capex_global_envelope_sats': (0, 100_000_000),
 }
 
@@ -414,6 +416,11 @@ class Config:
     capex_global_envelope_sats: int = 0         # Global cap (0 = auto-computed)
     capex_cost_efficiency_weight: float = 0.5   # Weight for cost-efficiency in dual-benefit score
     capex_drain_benefit_weight: float = 0.5     # Weight for drain-benefit in dual-benefit score
+    # Probability-aware budget relaxation. When a router reports a route
+    # probability (v3/askrene does; v2/getroute returns 0), the engine allows
+    # the route to exceed the raw pair budget by up to (probability * bonus)
+    # fraction. Default 0.0 = disabled, preserving v2 behavior exactly.
+    capex_probability_budget_bonus: float = 0.0
 
     # Internal version tracking (not a user-configurable option)
     _version: int = field(default=0, repr=False, compare=False)
@@ -790,6 +797,7 @@ class ConfigSnapshot:
     capex_global_envelope_sats: int = 0
     capex_cost_efficiency_weight: float = 0.5
     capex_drain_benefit_weight: float = 0.5
+    capex_probability_budget_bonus: float = 0.0
     # Version tracking
     version: int = 0
     

--- a/modules/rebalance_engine_v2.py
+++ b/modules/rebalance_engine_v2.py
@@ -217,7 +217,11 @@ class RebalanceEngine:
                 if route_result.success:
                     pair.route_cost_sats = route_result.route_cost_sats
                     pair.route = route_result.route
-                    if route_result.route_cost_sats <= pair.pair_budget_sats:
+                    effective_budget = self._probability_adjusted_budget(
+                        pair.pair_budget_sats,
+                        getattr(route_result, "probability_ppm", 0),
+                    )
+                    if route_result.route_cost_sats <= effective_budget:
                         priced.append(pair)
                         self._audit.log_pick(
                             pair.source_channel_id,
@@ -232,7 +236,11 @@ class RebalanceEngine:
                             reason="route_over_budget",
                             value_class="valuable",
                             remaining_budget_sats=pair.pair_budget_sats,
-                            detail=f"route_cost={route_result.route_cost_sats}",
+                            detail=(
+                                f"route_cost={route_result.route_cost_sats} "
+                                f"effective_budget={effective_budget} "
+                                f"probability_ppm={getattr(route_result, 'probability_ppm', 0)}"
+                            ),
                         ))
                 else:
                     plan.skipped.append(SkipRecord(
@@ -292,6 +300,33 @@ class RebalanceEngine:
     def _record_pair_success(self, source_channel_id: str, dest_channel_id: str) -> None:
         """Clear any failure history for this pair (success resets the counter)."""
         self._pair_failures.pop((source_channel_id, dest_channel_id), None)
+
+    def _probability_adjusted_budget(
+        self, pair_budget_sats: int, probability_ppm: int
+    ) -> int:
+        """Relax the raw pair budget by a probability-weighted bonus.
+
+        Returns the base pair_budget_sats unchanged when either the config
+        bonus rate is 0 (default) or the router reported no probability
+        (v2/getroute does this). With a positive bonus rate and non-zero
+        probability, the effective budget is:
+
+            pair_budget * (1 + clamp(probability_ppm, 0, 1_000_000) / 1_000_000 * bonus)
+
+        Example: bonus=0.25, probability_ppm=982_339 →
+            effective = pair_budget * (1 + 0.982339 * 0.25)
+                      = pair_budget * 1.2456
+
+        The intent is to unlock v3/askrene's high-probability-but-pricier
+        routes on topologies where v2/getroute's cheap paths are actually
+        unroutable (see Phase B test on nexus-01, 2026-04-10).
+        """
+        bonus_rate = getattr(self.config, "capex_probability_budget_bonus", 0.0)
+        if bonus_rate <= 0.0 or probability_ppm <= 0:
+            return pair_budget_sats
+        clamped = min(1.0, max(0.0, probability_ppm / 1_000_000.0))
+        bonus_fraction = clamped * bonus_rate
+        return int(pair_budget_sats * (1.0 + bonus_fraction))
 
     def _execute_pair(
         self,

--- a/modules/rebalance_router_v2.py
+++ b/modules/rebalance_router_v2.py
@@ -18,7 +18,14 @@ from typing import Any, Dict, List, Optional
 
 @dataclass
 class RouteResult:
-    """Result of a v2 route pricing attempt."""
+    """Result of a router's price_pair attempt.
+
+    Shared across v2 (getroute) and v3 (askrene getroutes) routers so the
+    engine consumes either transparently. probability_ppm is the router's
+    success-probability estimate in parts per million; v3/askrene populates
+    it from the MCF solver output, v2/getroute leaves it at 0 (unknown),
+    which the engine treats as "no probability-aware relaxation."
+    """
 
     success: bool
     route_cost_sats: int = 0
@@ -26,6 +33,7 @@ class RouteResult:
     hops: int = 0
     route: List[Dict[str, Any]] = field(default_factory=list)
     error: str = ""
+    probability_ppm: int = 0
 
 
 class RebalanceRouter:

--- a/tests/test_probability_aware_budget.py
+++ b/tests/test_probability_aware_budget.py
@@ -1,0 +1,140 @@
+"""Tests for probability-aware pair-budget relaxation.
+
+When a router reports a route's success probability (askrene does, via MCF;
+legacy getroute does not and leaves the field at 0), the engine allows the
+route to exceed the pair's raw budget by a configurable factor proportional
+to the probability. This unlocks v3's more-reliable-but-pricier paths on
+topologies where v2's cheap paths are unroutable.
+
+The default bonus is 0, preserving v2 behavior exactly.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# RouteResult.probability_ppm field
+# ---------------------------------------------------------------------------
+
+
+def test_route_result_has_probability_ppm_defaulting_to_zero():
+    from modules.rebalance_router_v2 import RouteResult
+    r = RouteResult(success=True)
+    assert r.probability_ppm == 0
+
+
+def test_route_result_accepts_probability_ppm_kwarg():
+    from modules.rebalance_router_v2 import RouteResult
+    r = RouteResult(success=True, probability_ppm=982339)
+    assert r.probability_ppm == 982339
+
+
+# ---------------------------------------------------------------------------
+# Config.capex_probability_budget_bonus
+# ---------------------------------------------------------------------------
+
+
+def test_config_has_capex_probability_budget_bonus_default_zero():
+    from modules.config import Config
+    cfg = Config()
+    assert cfg.capex_probability_budget_bonus == 0.0
+
+
+def test_config_capex_probability_budget_bonus_snapshot_round_trip():
+    from modules.config import Config
+    cfg = Config()
+    cfg.capex_probability_budget_bonus = 0.25
+    snap = cfg.snapshot()
+    assert snap.capex_probability_budget_bonus == 0.25
+
+
+def test_capex_probability_budget_bonus_in_field_type_map():
+    from modules.config import CONFIG_FIELD_TYPES
+    assert CONFIG_FIELD_TYPES.get("capex_probability_budget_bonus") is float
+
+
+def test_capex_probability_budget_bonus_has_range_constraint():
+    from modules.config import CONFIG_FIELD_RANGES
+    assert "capex_probability_budget_bonus" in CONFIG_FIELD_RANGES
+    lo, hi = CONFIG_FIELD_RANGES["capex_probability_budget_bonus"]
+    assert lo == 0.0
+    assert 0.5 <= hi <= 1.0  # reasonable upper bound
+
+
+# ---------------------------------------------------------------------------
+# Engine._probability_adjusted_budget formula
+# ---------------------------------------------------------------------------
+
+
+def _make_engine(bonus_rate: float = 0.0):
+    """Minimal RebalanceEngine with the given probability-budget bonus rate."""
+    from modules.rebalance_engine_v2 import RebalanceEngine
+
+    plugin = MagicMock()
+    plugin.rpc.call.side_effect = Exception("askrene unavailable")
+    plugin.rpc.getinfo.return_value = {"id": "03" + "u" * 64}
+
+    config = MagicMock()
+    config.rebalance_router = "v2"
+    config.askrene_layers = "hive-fleet"
+    config.capex_probability_budget_bonus = bonus_rate
+    del config.snapshot
+
+    database = MagicMock()
+    return RebalanceEngine(plugin=plugin, config=config, database=database)
+
+
+def test_adjusted_budget_returns_base_when_bonus_rate_zero():
+    engine = _make_engine(bonus_rate=0.0)
+    # 100% probability route with zero bonus rate should get no relaxation
+    assert engine._probability_adjusted_budget(355, 1_000_000) == 355
+    # 0% probability: also no change
+    assert engine._probability_adjusted_budget(355, 0) == 355
+
+
+def test_adjusted_budget_returns_base_when_probability_zero():
+    """V2 router returns probability_ppm=0 (unknown) — no relaxation even if bonus>0."""
+    engine = _make_engine(bonus_rate=0.25)
+    assert engine._probability_adjusted_budget(355, 0) == 355
+
+
+def test_adjusted_budget_scales_with_probability_linearly():
+    engine = _make_engine(bonus_rate=0.25)
+    # 100% probability: budget * (1 + 1.0 * 0.25) = budget * 1.25
+    assert engine._probability_adjusted_budget(400, 1_000_000) == 500
+    # 50% probability: budget * (1 + 0.5 * 0.25) = budget * 1.125
+    assert engine._probability_adjusted_budget(400, 500_000) == 450
+    # 98.2% probability (matches askrene's live v3 sample)
+    # budget * (1 + 0.982 * 0.25) = 400 * 1.2455 = 498
+    adjusted = engine._probability_adjusted_budget(400, 982_000)
+    assert 495 <= adjusted <= 500
+
+
+def test_adjusted_budget_clamps_probability_at_one_million():
+    """Defensive: bogus probability >1M should not over-inflate the budget."""
+    engine = _make_engine(bonus_rate=0.25)
+    assert engine._probability_adjusted_budget(400, 2_000_000) == 500  # same as 1M
+
+
+def test_adjusted_budget_unlocks_v3_observed_case():
+    """Realistic scenario from the 2026-04-10 nexus-01 Phase B test:
+    pair_budget=355, v3 route_cost=369 (14 sats over budget),
+    askrene probability 982339. With 25% bonus rate, the effective budget
+    becomes ~442 sats, letting the route through."""
+    engine = _make_engine(bonus_rate=0.25)
+    pair_budget = 355
+    v3_route_cost = 369
+    v3_probability = 982_339
+    effective = engine._probability_adjusted_budget(pair_budget, v3_probability)
+    assert effective >= v3_route_cost, (
+        f"effective budget {effective} should allow route cost {v3_route_cost}"
+    )
+
+
+def test_adjusted_budget_rejects_negative_bonus_rate():
+    """Config range should prevent this, but engine should handle defensively."""
+    engine = _make_engine(bonus_rate=-0.1)
+    # Negative bonus should clamp to 0, returning base budget
+    assert engine._probability_adjusted_budget(400, 1_000_000) == 400


### PR DESCRIPTION
When a router reports a route's success probability, the engine allows the route to exceed the pair's raw budget by a configurable bonus factor proportional to that probability. V3/askrene populates probability_ppm from its MCF solver output; v2/getroute has no probability model and leaves the field at 0, which the engine treats as 'no relaxation'.

Motivation: Phase B A/B test on nexus-01 (2026-04-10) showed that v3/askrene picks reliable routes with higher fees than v2/getroute's cheap routes, but v2's cheap routes fail execution at runtime (we observed the same pair fail twice with erring_channel=None at 17:17 and 17:26). V3's 369-sat route with 98.2% askrene probability was rejected as route_over_budget vs the pair's raw 355-sat budget. A 25% probability-weighted bonus would make the effective budget ~442 sats, letting v3's reliable route through while still rejecting obviously-wrong candidates.

Changes:
- modules/rebalance_router_v2.py: add probability_ppm: int = 0 to RouteResult dataclass. v2 router leaves it at 0; v3 router will populate it from askrene's response on the v3 branch.
- modules/config.py: add capex_probability_budget_bonus: float = 0.0 (default 0.0 preserves v2 behavior exactly). Range [0.0, 1.0]. Mirrored in ConfigSnapshot and CONFIG_FIELD_TYPES/RANGES.
- modules/rebalance_engine_v2.py: new _probability_adjusted_budget() method applies the formula budget * (1 + prob_ppm/1M * bonus). find_candidates() uses the adjusted budget in the route_over_budget check and now includes probability_ppm + effective_budget in the skip detail for audit visibility.
- tests/test_probability_aware_budget.py: 12 new tests covering RouteResult field, Config defaults/ranges, formula edge cases (zero bonus, zero probability, clamping at 1M, negative bonus defensive path, 98.2% scenario matching the live observation).

Full suite: 1371 passing (+12), only the pre-existing test_hive_live_contract failure remains.