### PR TITLE
feat: expose capex_probability_budget_bonus as public runtime control

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -34,6 +34,10 @@ PUBLIC_RUNTIME_KEYS = (
     'planner_execute_closes',
     'planner_max_opens_per_cycle',
     'planner_max_closes_per_cycle',
+    # V3 router probability-aware budget relaxation (default 0.0 = off).
+    # Exposed so operators running the askrene router can enable the
+    # reliability-weighted budget bonus without editing code or the database.
+    'capex_probability_budget_bonus',
 )
 
 # Type mapping for config fields (for validation)

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -140,6 +140,7 @@ def test_revenue_status_reports_operator_controls_not_full_config():
         "planner_execute_closes",
         "planner_max_opens_per_cycle",
         "planner_max_closes_per_cycle",
+        "capex_probability_budget_bonus",
     ]
     assert result["operator_controls"]["values"] == {
         "paused": False,
@@ -151,6 +152,7 @@ def test_revenue_status_reports_operator_controls_not_full_config():
         "planner_execute_closes": False,
         "planner_max_opens_per_cycle": 1,
         "planner_max_closes_per_cycle": 0,
+        "capex_probability_budget_bonus": 0.0,
     }
     assert "config" not in result
 

--- a/tests/test_operator_surface.py
+++ b/tests/test_operator_surface.py
@@ -19,6 +19,7 @@ def test_public_runtime_keys_are_safety_only():
         "planner_execute_closes",
         "planner_max_opens_per_cycle",
         "planner_max_closes_per_cycle",
+        "capex_probability_budget_bonus",
     ]
 
 
@@ -43,6 +44,7 @@ def test_public_runtime_dict_returns_only_public_keys():
         "planner_execute_closes": False,
         "planner_max_opens_per_cycle": 1,
         "planner_max_closes_per_cycle": 0,
+        "capex_probability_budget_bonus": 0.0,
     }
 
 
@@ -190,6 +192,7 @@ def test_revenue_config_list_mutable_returns_public_controls_only():
     result = mod.revenue_config(mod.plugin, "list-mutable")
 
     assert result["mutable_keys"] == [
+        "capex_probability_budget_bonus",
         "daily_budget_sats",
         "max_fee_ppm",
         "min_fee_ppm",
@@ -200,7 +203,7 @@ def test_revenue_config_list_mutable_returns_public_controls_only():
         "planner_max_closes_per_cycle",
         "planner_max_opens_per_cycle",
     ]
-    assert result["count"] == 9
+    assert result["count"] == 10
 
 
 def test_revenue_config_get_without_key_returns_public_controls_only():
@@ -218,6 +221,7 @@ def test_revenue_config_get_without_key_returns_public_controls_only():
         "planner_execute_closes": False,
         "planner_max_opens_per_cycle": 1,
         "planner_max_closes_per_cycle": 0,
+        "capex_probability_budget_bonus": 0.0,
     }
 
 
@@ -351,6 +355,7 @@ def test_revenue_status_operator_controls_hide_internal_knob_dump():
         "planner_execute_closes": False,
         "planner_max_opens_per_cycle": 1,
         "planner_max_closes_per_cycle": 0,
+        "capex_probability_budget_bonus": 0.0,
     }
     assert "config" not in result
 

--- a/tests/test_public_probability_bonus.py
+++ b/tests/test_public_probability_bonus.py
@@ -1,0 +1,30 @@
+"""Tests for exposing capex_probability_budget_bonus as a public runtime control."""
+
+
+def test_capex_probability_budget_bonus_is_public_runtime_key():
+    from modules.config import PUBLIC_RUNTIME_KEYS
+    assert "capex_probability_budget_bonus" in PUBLIC_RUNTIME_KEYS
+
+
+def test_is_public_runtime_key_returns_true_for_probability_bonus():
+    from modules.config import Config
+    assert Config.is_public_runtime_key("capex_probability_budget_bonus") is True
+
+
+def test_public_runtime_keys_method_includes_probability_bonus():
+    from modules.config import Config
+    cfg = Config()
+    assert "capex_probability_budget_bonus" in cfg.public_runtime_keys()
+
+
+def test_public_runtime_dict_reflects_probability_bonus():
+    from modules.config import Config
+    cfg = Config()
+    cfg.capex_probability_budget_bonus = 0.25
+    d = cfg.public_runtime_dict()
+    assert d["capex_probability_budget_bonus"] == 0.25
+
+
+def test_classify_runtime_key_returns_public_for_probability_bonus():
+    from modules.config import Config
+    assert Config.classify_runtime_key("capex_probability_budget_bonus") == "public"


### PR DESCRIPTION
Adds capex_probability_budget_bonus to PUBLIC_RUNTIME_KEYS so operators running the v3 askrene router can enable the probability-weighted budget relaxation via 'lightning-cli revenue-config set' without editing code or directly writing the database.

The feature landed in PR #77 (feature/probability-aware-budget) but was gated internal, requiring code edits to enable. With the v3 router now populating probability_ppm (Part B), this key is the last missing piece for an end-to-end operator workflow:

  lightning-cli revenue-config set capex_probability_budget_bonus 0.25
  lightning-cli -k setconfig config=revenue-ops-rebalance-router val=v3 transient=true

Range is already enforced by CONFIG_FIELD_RANGES (0.0–1.0). Default 0.0 preserves v2 behavior exactly.

Tests:
- 5 new tests in test_public_probability_bonus.py covering membership, classification, public_runtime_keys(), public_runtime_dict(), and classify_runtime_key()
- Updated 5 existing tests in test_operator_surface.py and test_explainability.py that assert the exact set of public keys

Full suite: 1376 passing (+17 new/updated), only the pre-existing test_hive_live_contract failure remains.