### PR TITLE
feat: add full-fidelity executor failure diagnostics

### DIFF
--- a/modules/rebalance_executor_v2.py
+++ b/modules/rebalance_executor_v2.py
@@ -175,6 +175,16 @@ class RebalanceExecutor:
             return result
 
         except Exception as e:
+            # Full-fidelity diagnostic log BEFORE structured extraction, so we
+            # never lose information when the exception shape is unexpected.
+            # This replaces the old 'Failed:  erring_channel=None' log that
+            # masked any non-conforming failure mode (timeouts, non-RpcError
+            # exceptions, missing error.data fields). See Phase B Task 3
+            # investigation on nexus-01 2026-04-10: the blank-failcode log
+            # turned out to hide a completely opaque failure, and adding
+            # this diagnostic is the first step to figuring out why.
+            self._log_executor_failure(e)
+
             error_data = self._extract_error_data(e)
             erring_channel = error_data.get("erring_channel")
             failcode = error_data.get("failcodename", "")
@@ -198,12 +208,64 @@ class RebalanceExecutor:
 
         return result
 
+    def _log_executor_failure(self, exc: Exception) -> None:
+        """Emit a full diagnostic dump of a sendpay/waitsendpay failure.
+
+        Captures exception type, repr, whether it has an .error attribute,
+        the shape of that .error (dict vs str), the top-level keys, and the
+        keys of .error.data if present. This produces one machine-grep'able
+        line per failure so operators can diagnose cases the structured
+        extractor misses without re-running with strace.
+        """
+        exc_type = type(exc).__name__
+        exc_repr = repr(exc)
+        err_attr = getattr(exc, "error", None)
+
+        if err_attr is None:
+            self._log(
+                f"EXECUTOR_FAIL_DIAG type={exc_type} has_error_attr=no "
+                f"repr={exc_repr}",
+                level="warn",
+            )
+            return
+
+        if isinstance(err_attr, dict):
+            top_keys = sorted(err_attr.keys())
+            data = err_attr.get("data")
+            data_keys = (
+                sorted(data.keys()) if isinstance(data, dict) else None
+            )
+            message = err_attr.get("message", "")
+            code = err_attr.get("code")
+            self._log(
+                f"EXECUTOR_FAIL_DIAG type={exc_type} "
+                f"err_code={code} err_message={message!r} "
+                f"err_keys={top_keys} data_keys={data_keys} "
+                f"err_dict={err_attr!r}",
+                level="warn",
+            )
+            return
+
+        self._log(
+            f"EXECUTOR_FAIL_DIAG type={exc_type} err_attr_type={type(err_attr).__name__} "
+            f"err_attr={err_attr!r} repr={exc_repr}",
+            level="warn",
+        )
+
     def _extract_error_data(self, error: Exception) -> Dict[str, Any]:
-        """Extract structured error data from RPC exception."""
+        """Extract structured error data from RPC exception.
+
+        Returns error.error['data'] as a dict if the exception is an
+        RpcError with a nested 'data' dict. Returns {} for any other
+        shape — the full diagnostic is logged separately by
+        _log_executor_failure so nothing is silently discarded.
+        """
         if hasattr(error, "error"):
             err = error.error
             if isinstance(err, dict):
-                return err.get("data", {})
+                data = err.get("data")
+                if isinstance(data, dict):
+                    return data
         return {}
 
     def _cleanup(

--- a/tests/test_rebalance_executor_v2.py
+++ b/tests/test_rebalance_executor_v2.py
@@ -232,6 +232,129 @@ class TestExecutorFailures:
         assert result.success is False
         assert "444x4x0" in result.excluded_channels
 
+    def test_diagnostic_log_fires_on_bare_exception(self):
+        """When waitsendpay raises a plain Exception with no .error attr,
+        the executor must emit EXECUTOR_FAIL_DIAG so operators can still
+        diagnose what happened. Regression guard for the Phase B Task 3
+        observation on nexus-01 2026-04-10 where 'Failed:  erring_channel=None'
+        masked the actual failure mode."""
+        executor, plugin = _make_executor()
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "abc123",
+            "bolt11": "lnbc...",
+        }
+
+        plugin.rpc.waitsendpay.side_effect = Exception("socket timeout")
+
+        executor.execute(
+            route=_make_route(),
+            amount_sats=50_000,
+            source_channel_id="111x1x0",
+            dest_channel_id="222x2x0",
+            max_fee_sats=10,
+        )
+
+        log_calls = [c.args[0] for c in plugin.log.call_args_list]
+        diag = [l for l in log_calls if "EXECUTOR_FAIL_DIAG" in l]
+        assert diag, f"expected EXECUTOR_FAIL_DIAG log, got: {log_calls}"
+        assert "has_error_attr=no" in diag[0]
+        assert "socket timeout" in diag[0]
+
+    def test_diagnostic_log_fires_on_rpc_error_with_empty_data(self):
+        """When waitsendpay raises an RpcError whose .error dict has no
+        'data' field (or an empty dict), EXECUTOR_FAIL_DIAG must show the
+        actual keys present so operators can see what CLN returned."""
+        executor, plugin = _make_executor()
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "abc123",
+            "bolt11": "lnbc...",
+        }
+
+        class RPCError(Exception):
+            def __init__(self):
+                super().__init__("payment failed")
+                self.error = {
+                    "code": 203,
+                    "message": "Ran out of routes to try",
+                    # No 'data' field on purpose
+                }
+
+        plugin.rpc.waitsendpay.side_effect = RPCError()
+
+        executor.execute(
+            route=_make_route(),
+            amount_sats=50_000,
+            source_channel_id="111x1x0",
+            dest_channel_id="222x2x0",
+            max_fee_sats=10,
+        )
+
+        log_calls = [c.args[0] for c in plugin.log.call_args_list]
+        diag = [l for l in log_calls if "EXECUTOR_FAIL_DIAG" in l]
+        assert diag, f"expected EXECUTOR_FAIL_DIAG log, got: {log_calls}"
+        assert "err_code=203" in diag[0]
+        assert "Ran out of routes to try" in diag[0]
+        assert "data_keys=None" in diag[0]
+
+    def test_diagnostic_log_shows_data_keys_when_present(self):
+        """Happy-path diagnostic: when data is a proper dict, its keys
+        appear in the log line."""
+        executor, plugin = _make_executor()
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "abc123",
+            "bolt11": "lnbc...",
+        }
+
+        class RPCError(Exception):
+            def __init__(self):
+                self.error = {
+                    "code": 203,
+                    "message": "Failed",
+                    "data": {
+                        "erring_channel": "555x5x0",
+                        "failcodename": "WIRE_TEMPORARY_CHANNEL_FAILURE",
+                        "erring_index": 1,
+                    },
+                }
+
+        plugin.rpc.waitsendpay.side_effect = RPCError()
+
+        executor.execute(
+            route=_make_route(),
+            amount_sats=50_000,
+            source_channel_id="111x1x0",
+            dest_channel_id="222x2x0",
+            max_fee_sats=10,
+        )
+
+        log_calls = [c.args[0] for c in plugin.log.call_args_list]
+        diag = [l for l in log_calls if "EXECUTOR_FAIL_DIAG" in l]
+        assert diag, f"expected EXECUTOR_FAIL_DIAG log, got: {log_calls}"
+        line = diag[0]
+        assert "erring_channel" in line
+        assert "failcodename" in line
+        assert "erring_index" in line
+
+    def test_extract_error_data_only_accepts_dict_data_field(self):
+        """Regression guard: _extract_error_data used to return err.get('data', {})
+        without type-checking, so a string data field would crash the
+        downstream .get() call. Now returns {} for any non-dict data."""
+        executor, _ = _make_executor()
+
+        class RPCErrStringData(Exception):
+            def __init__(self):
+                self.error = {"data": "a string, not a dict"}
+
+        result = executor._extract_error_data(RPCErrStringData())
+        assert result == {}
+
+        class RPCErrNoData(Exception):
+            def __init__(self):
+                self.error = {"code": 123}
+
+        result = executor._extract_error_data(RPCErrNoData())
+        assert result == {}
+
     def test_cleanup_delpays_on_failure(self):
         executor, plugin = _make_executor()
         plugin.rpc.invoice.return_value = {


### PR DESCRIPTION
Adds _log_executor_failure() which emits an EXECUTOR_FAIL_DIAG log line BEFORE the structured extraction path. Captures the full shape of the exception so operators can diagnose failure modes that the structured extractor misses — specifically the blank 'Failed:
 erring_channel=None' log line that has been masking the real
failure for the recurring pair 932263x1883x0 → 939858x2330x0 on nexus-01.

Fields in the new diag line:
- type: exception class name
- err_code / err_message: top-level JSONRPC error fields
- err_keys: all keys present on exc.error (dict path)
- data_keys: all keys on exc.error['data'] if it's a dict (None otherwise)
- err_dict: full repr of exc.error for copy-paste reproduction
- has_error_attr=no + repr: fallback for plain Exception types

Also hardens _extract_error_data so a non-dict 'data' field no longer crashes the downstream .get() — now returns {} cleanly.

4 new tests cover: plain Exception with no .error, RpcError with empty/missing data, RpcError with populated data (regression guard for the happy path), and the extractor's defensive handling of non-dict data.

Phase B Task #3 (executor erring_channel=None investigation). With this deployed on nexus-01, the next executor failure will print its actual failure mode instead of a blank log line.