### PR TITLE
feat: exclude-aware retry in _execute_pair for retriable failures

### DIFF
--- a/modules/rebalance_engine_v2.py
+++ b/modules/rebalance_engine_v2.py
@@ -333,7 +333,18 @@ class RebalanceEngine:
         pair: PairCandidate,
         executor: RebalanceExecutor,
     ) -> Optional[ExecutionResult]:
-        """Execute a single pair in a worker thread."""
+        """Execute a single pair in a worker thread.
+
+        On retriable failure with an erring channel, re-prices the pair
+        with the failing channel excluded and attempts one retry. Covers
+        the common stale-gossip WIRE_FEE_INSUFFICIENT case where the
+        first attempt picks an intermediate whose real fee is higher
+        than gossip shows — the retry picks a different path that
+        bypasses the failing hop.
+
+        Only one retry per call, by design: unbounded retry would cascade
+        exclude layers and waste budget on repeatedly-failing topology.
+        """
         if not pair.route:
             self._log(
                 f"No route stored for {pair.source_channel_id}->"
@@ -356,8 +367,99 @@ class RebalanceEngine:
                 f"{pair.source_channel_id}->{pair.dest_channel_id} "
                 f"fee={exec_result.fee_sats} sats"
             )
+            return exec_result
 
+        # Retry on retriable failures that identified a specific bad hop.
+        # Permanent failures (channel disabled, unknown peer) can't be
+        # usefully retried with an exclude — the pair is dead for this cycle.
+        if not self._should_retry_with_exclude(exec_result):
+            return exec_result
+
+        retry_result = self._attempt_retry_with_exclude(pair, executor, exec_result)
+        if retry_result is not None:
+            return retry_result
         return exec_result
+
+    @staticmethod
+    def _should_retry_with_exclude(exec_result: "ExecutionResult") -> bool:
+        """Return True iff the executor failure is retriable AND it identified
+        at least one excluded channel we can try to route around."""
+        error = exec_result.error or ""
+        if "retriable_failure" not in error:
+            return False
+        return bool(exec_result.excluded_channels)
+
+    def _attempt_retry_with_exclude(
+        self,
+        pair: PairCandidate,
+        executor: RebalanceExecutor,
+        original_failure: "ExecutionResult",
+    ) -> Optional["ExecutionResult"]:
+        """Re-price the pair with the failing channel excluded, execute once.
+
+        Returns the retry ExecutionResult on actual retry (success or fail),
+        or None if the retry was abandoned (no route / over budget / no
+        router available). Caller treats None as "stick with original_failure".
+        """
+        router = getattr(self, "_cycle_router", None)
+        if router is None:
+            return None
+
+        self._log(
+            f"Retrying {pair.source_channel_id}->{pair.dest_channel_id} with "
+            f"exclude={original_failure.excluded_channels}",
+            level="info",
+        )
+        try:
+            new_route = router.price_pair(
+                source_channel_id=pair.source_channel_id,
+                dest_channel_id=pair.dest_channel_id,
+                source_peer_id=pair.source_peer_id,
+                dest_peer_id=pair.dest_peer_id,
+                amount_sats=pair.amount_sats,
+                exclude=list(original_failure.excluded_channels),
+            )
+        except Exception as e:
+            self._log(
+                f"Retry re-price raised {type(e).__name__}: {e}", level="warn"
+            )
+            return None
+
+        if not new_route.success:
+            self._log(
+                f"Retry re-price returned no route: {new_route.error}",
+                level="info",
+            )
+            return None
+
+        effective_budget = self._probability_adjusted_budget(
+            pair.pair_budget_sats,
+            getattr(new_route, "probability_ppm", 0),
+        )
+        if new_route.route_cost_sats > effective_budget:
+            self._log(
+                f"Retry re-price over budget: route_cost={new_route.route_cost_sats} "
+                f"effective_budget={effective_budget}",
+                level="info",
+            )
+            return None
+
+        pair.route = new_route.route
+        pair.route_cost_sats = new_route.route_cost_sats
+
+        retry_result = executor.execute(
+            route=pair.route,
+            amount_sats=pair.amount_sats,
+            source_channel_id=pair.source_channel_id,
+            dest_channel_id=pair.dest_channel_id,
+            max_fee_sats=pair.pair_budget_sats,
+        )
+        if retry_result.success:
+            self._log(
+                f"Retry succeeded: {pair.source_channel_id}->"
+                f"{pair.dest_channel_id} fee={retry_result.fee_sats} sats"
+            )
+        return retry_result
 
     def run_cycle(self) -> CycleResult:
         """Live execution: find candidates (already priced), execute concurrently.

--- a/tests/test_engine_retry_with_exclude.py
+++ b/tests/test_engine_retry_with_exclude.py
@@ -1,0 +1,313 @@
+"""Tests for exclude-aware retry in RebalanceEngine._execute_pair.
+
+When the executor reports a retriable failure with excluded_channels
+populated, the engine re-prices the pair with those channels excluded
+and attempts one retry. This unblocks the recurring pattern where a
+stale-gossip WIRE_FEE_INSUFFICIENT failure on the same intermediate
+channel would otherwise loop every 15 minutes until the futility
+tracker stops it — instead, the retry picks a different path and
+the pair can actually succeed.
+
+Origin: Phase B Task #5 on nexus-01 2026-04-10 18:39Z. Executor
+correctly reports erring_channel=934667x311x8 after the RPC proxy
+fix (PR #80), but without this retry the next cycle re-picks the
+same failing route.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_engine_with_mocked_router():
+    """Build a minimal engine whose _cycle_router is a MagicMock."""
+    from modules.rebalance_engine_v2 import RebalanceEngine
+    from modules.rebalance_router_v2 import RouteResult
+
+    plugin = MagicMock()
+    plugin.rpc.call.side_effect = Exception("askrene unavailable")
+    plugin.rpc.getinfo.return_value = {"id": "03" + "u" * 64}
+
+    config = MagicMock()
+    config.rebalance_router = "v2"
+    config.askrene_layers = "hive-fleet"
+    config.capex_probability_budget_bonus = 0.0
+    del config.snapshot
+
+    database = MagicMock()
+    engine = RebalanceEngine(plugin=plugin, config=config, database=database)
+
+    # Install a mock router as the cycle router so _execute_pair can call it
+    mock_router = MagicMock()
+    engine._cycle_router = mock_router
+    return engine, mock_router
+
+
+def _make_pair(
+    source_scid="100x1x0",
+    dest_scid="200x2x0",
+    pair_budget_sats=500,
+    amount_sats=1000,
+):
+    from modules.rebalance_types_v2 import PairCandidate
+    return PairCandidate(
+        source_channel_id=source_scid,
+        dest_channel_id=dest_scid,
+        source_peer_id="03" + "a" * 64,
+        dest_peer_id="03" + "b" * 64,
+        amount_sats=amount_sats,
+        pair_budget_sats=pair_budget_sats,
+        score=0.5,
+        source_local_ratio=0.9,
+        dest_local_ratio=0.2,
+        route=[{"id": "03" + "a" * 64, "channel": source_scid, "amount_msat": 1005000, "delay": 100}],
+        route_cost_sats=5,
+    )
+
+
+def _make_execution_result(success: bool, error: str = "", excluded: list = None):
+    from modules.rebalance_executor_v2 import ExecutionResult
+    return ExecutionResult(
+        success=success,
+        attempts=1,
+        fee_sats=5 if success else 0,
+        fee_msat=5000 if success else 0,
+        amount_sats=1000,
+        error=error,
+        excluded_channels=excluded or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Retry happy path
+# ---------------------------------------------------------------------------
+
+
+def test_execute_pair_retries_on_retriable_failure_with_exclude():
+    """Retriable failure with excluded_channels → router re-priced with exclude,
+    new route installed, second execution attempt made."""
+    from modules.rebalance_router_v2 import RouteResult
+
+    engine, mock_router = _make_engine_with_mocked_router()
+
+    pair = _make_pair(pair_budget_sats=500)
+
+    # First execute: fails retriably with an erring channel
+    first_fail = _make_execution_result(
+        success=False,
+        error="retriable_failure: WIRE_FEE_INSUFFICIENT",
+        excluded=["934667x311x8"],
+    )
+    # Second execute (after re-price): success
+    second_success = _make_execution_result(success=True)
+
+    executor = MagicMock()
+    executor.execute.side_effect = [first_fail, second_success]
+
+    # Re-price returns a cheaper route that fits the budget
+    mock_router.price_pair.return_value = RouteResult(
+        success=True,
+        route_cost_sats=7,
+        final_hop_fee_ppm=100,
+        hops=2,
+        route=[
+            {"id": "03" + "a" * 64, "channel": "100x1x0", "amount_msat": 1007000, "delay": 100},
+            {"id": "03" + "u" * 64, "channel": "200x2x0", "amount_msat": 1000000, "delay": 40},
+        ],
+        probability_ppm=980000,
+    )
+
+    result = engine._execute_pair(pair, executor)
+
+    # Two execute() calls: original + retry
+    assert executor.execute.call_count == 2
+    # Router was re-priced with the exclude list
+    mock_router.price_pair.assert_called_once()
+    call_kwargs = mock_router.price_pair.call_args.kwargs
+    assert call_kwargs["exclude"] == ["934667x311x8"]
+    assert call_kwargs["source_channel_id"] == "100x1x0"
+    # Final result is the retry success
+    assert result.success is True
+
+
+def test_execute_pair_does_not_retry_on_permanent_failure():
+    """Permanent failures (channel disabled, etc.) must not trigger retry."""
+    engine, mock_router = _make_engine_with_mocked_router()
+    pair = _make_pair()
+
+    perm_fail = _make_execution_result(
+        success=False,
+        error="permanent_failure: WIRE_CHANNEL_DISABLED",
+        excluded=["111x1x1"],
+    )
+    executor = MagicMock()
+    executor.execute.return_value = perm_fail
+
+    result = engine._execute_pair(pair, executor)
+
+    assert executor.execute.call_count == 1
+    mock_router.price_pair.assert_not_called()
+    assert result.success is False
+    assert "permanent_failure" in result.error
+
+
+def test_execute_pair_does_not_retry_when_no_exclude_reported():
+    """Retriable failure without excluded_channels can't be usefully retried."""
+    engine, mock_router = _make_engine_with_mocked_router()
+    pair = _make_pair()
+
+    fail_no_exclude = _make_execution_result(
+        success=False,
+        error="retriable_failure: WIRE_TEMPORARY_NODE_FAILURE",
+        excluded=[],
+    )
+    executor = MagicMock()
+    executor.execute.return_value = fail_no_exclude
+
+    result = engine._execute_pair(pair, executor)
+
+    assert executor.execute.call_count == 1
+    mock_router.price_pair.assert_not_called()
+    assert result.success is False
+
+
+def test_execute_pair_retry_fails_when_reprice_returns_no_route():
+    """If the router can't find an alternative path with the exclude, the
+    original failure stands."""
+    from modules.rebalance_router_v2 import RouteResult
+
+    engine, mock_router = _make_engine_with_mocked_router()
+    pair = _make_pair()
+
+    first_fail = _make_execution_result(
+        success=False,
+        error="retriable_failure: WIRE_FEE_INSUFFICIENT",
+        excluded=["934667x311x8"],
+    )
+    executor = MagicMock()
+    executor.execute.return_value = first_fail
+
+    mock_router.price_pair.return_value = RouteResult(
+        success=False, error="no_route: all alternatives excluded"
+    )
+
+    result = engine._execute_pair(pair, executor)
+
+    assert executor.execute.call_count == 1  # no retry submitted
+    mock_router.price_pair.assert_called_once()
+    assert result.success is False
+    # Original failure preserved
+    assert "WIRE_FEE_INSUFFICIENT" in result.error
+
+
+def test_execute_pair_retry_fails_when_reprice_over_budget():
+    """If the alternative route exceeds the pair budget (even probability-adjusted),
+    no retry is attempted."""
+    from modules.rebalance_router_v2 import RouteResult
+
+    engine, mock_router = _make_engine_with_mocked_router()
+    pair = _make_pair(pair_budget_sats=10)  # very tight budget
+
+    first_fail = _make_execution_result(
+        success=False,
+        error="retriable_failure: WIRE_FEE_INSUFFICIENT",
+        excluded=["934667x311x8"],
+    )
+    executor = MagicMock()
+    executor.execute.return_value = first_fail
+
+    # Alternative route costs way more than budget
+    mock_router.price_pair.return_value = RouteResult(
+        success=True,
+        route_cost_sats=500,  # 50x the budget
+        final_hop_fee_ppm=100,
+        hops=2,
+        route=[],
+    )
+
+    result = engine._execute_pair(pair, executor)
+
+    assert executor.execute.call_count == 1  # no retry
+    assert result.success is False
+
+
+def test_execute_pair_retry_second_failure_returned():
+    """If both original and retry fail, the retry's failure is returned
+    (the retry is what the operator actually ran)."""
+    from modules.rebalance_router_v2 import RouteResult
+
+    engine, mock_router = _make_engine_with_mocked_router()
+    pair = _make_pair()
+
+    first_fail = _make_execution_result(
+        success=False,
+        error="retriable_failure: WIRE_FEE_INSUFFICIENT",
+        excluded=["934667x311x8"],
+    )
+    second_fail = _make_execution_result(
+        success=False,
+        error="retriable_failure: WIRE_TEMPORARY_CHANNEL_FAILURE",
+        excluded=["222x2x0"],
+    )
+
+    executor = MagicMock()
+    executor.execute.side_effect = [first_fail, second_fail]
+
+    mock_router.price_pair.return_value = RouteResult(
+        success=True,
+        route_cost_sats=7,
+        final_hop_fee_ppm=100,
+        hops=2,
+        route=[
+            {"id": "03" + "a" * 64, "channel": "100x1x0", "amount_msat": 1007000, "delay": 100},
+            {"id": "03" + "u" * 64, "channel": "200x2x0", "amount_msat": 1000000, "delay": 40},
+        ],
+    )
+
+    result = engine._execute_pair(pair, executor)
+
+    assert executor.execute.call_count == 2
+    assert result.success is False
+    # The returned result should be the retry attempt's failure
+    assert "WIRE_TEMPORARY_CHANNEL_FAILURE" in result.error
+
+
+def test_execute_pair_retry_does_not_loop_infinitely():
+    """Maximum one retry per pair per cycle — even if the second failure
+    also has excluded_channels, no third attempt is made."""
+    from modules.rebalance_router_v2 import RouteResult
+
+    engine, mock_router = _make_engine_with_mocked_router()
+    pair = _make_pair()
+
+    first_fail = _make_execution_result(
+        success=False,
+        error="retriable_failure: WIRE_FEE_INSUFFICIENT",
+        excluded=["aaa"],
+    )
+    second_fail = _make_execution_result(
+        success=False,
+        error="retriable_failure: WIRE_FEE_INSUFFICIENT",
+        excluded=["bbb"],
+    )
+
+    executor = MagicMock()
+    executor.execute.side_effect = [first_fail, second_fail]
+
+    mock_router.price_pair.return_value = RouteResult(
+        success=True,
+        route_cost_sats=7,
+        final_hop_fee_ppm=100,
+        hops=2,
+        route=[
+            {"id": "03" + "a" * 64, "channel": "100x1x0", "amount_msat": 1007000, "delay": 100},
+            {"id": "03" + "u" * 64, "channel": "200x2x0", "amount_msat": 1000000, "delay": 40},
+        ],
+    )
+
+    result = engine._execute_pair(pair, executor)
+
+    # Exactly 2 execute calls (original + one retry), NOT 3
+    assert executor.execute.call_count == 2
+    # Exactly 1 price_pair call for the retry
+    assert mock_router.price_pair.call_count == 1


### PR DESCRIPTION
When the executor returns a retriable failure with excluded_channels populated (e.g. WIRE_FEE_INSUFFICIENT identifying the exact hop that rejected the HTLC), _execute_pair now:

1. Calls self._cycle_router.price_pair() with the exclude list
2. Validates the new route's cost against the probability-adjusted pair budget (re-using the formula from PR #77)
3. Updates pair.route to the new route and calls executor.execute() once more
4. Returns the retry result (success or retry failure)

If the re-price returns no route, if the new route exceeds budget, or if the original failure was permanent / had no excluded_channels, the retry is abandoned and the original failure stands.

Limited to ONE retry per call, by design: unbounded retry would cascade exclude layers and waste budget on repeatedly-failing topology. The futility tracker (PR #76) handles the cross-cycle abandon case.

Motivation: Phase B Task #5 — after PR #80 fixed the RPC proxy kwarg collision, nexus-01 started reporting legitimate WIRE_FEE_INSUFFICIENT failures at specific intermediate channels. The executor captures the erring_channel but without this change the engine never used it, so every cycle re-picked the same stale route. With the retry, the second attempt routes around the failing hop via a completely different path and has a real chance of succeeding.

7 tests in test_engine_retry_with_exclude.py cover:
- happy path (retry succeeds)
- permanent failure (no retry)
- retriable without excluded_channels (no retry)
- retry re-price returns no route (original failure preserved)
- retry re-price over budget (no retry)
- retry also fails (retry result returned, not original)
- bounded: exactly 2 executor calls max, never 3

Full suite: 1391 passing, only the pre-existing test_hive_live_contract failure remains.