### PR TITLE
fix: capture erring_direction in excluded_channels as scid/dir

### DIFF
--- a/modules/rebalance_executor_v2.py
+++ b/modules/rebalance_executor_v2.py
@@ -187,15 +187,31 @@ class RebalanceExecutor:
 
             error_data = self._extract_error_data(e)
             erring_channel = error_data.get("erring_channel")
+            erring_direction = error_data.get("erring_direction")
             failcode = error_data.get("failcodename", "")
 
+            # Combine channel + direction into CLN's canonical exclude
+            # format (``scid/dir``). Both getroute and askrene's update-channel
+            # reject bare SCIDs:
+            #   "exclude: should be short_channel_id_dir or node_id: invalid token"
+            # (observed live on nexus-01 2026-04-10 18:54Z during the first
+            # engine retry attempt). When direction is missing from the
+            # error data, fall back to the bare SCID — a future call that
+            # needs directional precision can expand both dirs.
+            excluded_entry: Optional[str] = None
+            if erring_channel:
+                if erring_direction is not None:
+                    excluded_entry = f"{erring_channel}/{int(erring_direction)}"
+                else:
+                    excluded_entry = str(erring_channel)
+
             self._log(
-                f"Failed: {failcode} erring_channel={erring_channel}",
+                f"Failed: {failcode} erring_channel={excluded_entry}",
                 level="info",
             )
 
-            if erring_channel:
-                result.excluded_channels = [erring_channel]
+            if excluded_entry:
+                result.excluded_channels = [excluded_entry]
 
             if failcode in (
                 "WIRE_PERMANENT_CHANNEL_FAILURE",

--- a/tests/test_rebalance_executor_v2.py
+++ b/tests/test_rebalance_executor_v2.py
@@ -215,6 +215,7 @@ class TestExecutorFailures:
                 self.error = {
                     "data": {
                         "erring_channel": "444x4x0",
+                        "erring_direction": 1,
                         "failcodename": "WIRE_TEMPORARY_CHANNEL_FAILURE",
                     }
                 }
@@ -230,7 +231,75 @@ class TestExecutorFailures:
         )
 
         assert result.success is False
-        assert "444x4x0" in result.excluded_channels
+        # Must be in directional form ``scid/dir`` so getroute and askrene
+        # accept it in their exclude parameters.
+        assert result.excluded_channels == ["444x4x0/1"]
+
+    def test_exclude_captures_directional_form_when_direction_present(self):
+        """Regression guard: live nexus-01 2026-04-10 18:54Z showed getroute
+        rejecting bare SCIDs in the exclude list with
+        'exclude: should be short_channel_id_dir or node_id'. The executor
+        must combine erring_channel + erring_direction into CLN's canonical
+        ``scid/dir`` format."""
+        executor, plugin = _make_executor()
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "abc123",
+            "bolt11": "lnbc...",
+        }
+
+        class RPCError(Exception):
+            def __init__(self):
+                self.error = {
+                    "data": {
+                        "erring_channel": "934667x311x8",
+                        "erring_direction": 0,
+                        "failcodename": "WIRE_FEE_INSUFFICIENT",
+                    }
+                }
+
+        plugin.rpc.waitsendpay.side_effect = RPCError()
+
+        result = executor.execute(
+            route=_make_route(),
+            amount_sats=50_000,
+            source_channel_id="111x1x0",
+            dest_channel_id="222x2x0",
+            max_fee_sats=10,
+        )
+
+        assert result.excluded_channels == ["934667x311x8/0"]
+
+    def test_exclude_falls_back_to_bare_scid_when_direction_missing(self):
+        """Some older CLN versions or wrapped failures may omit
+        erring_direction. The executor should still produce a non-empty
+        excluded_channels entry rather than dropping the hint entirely."""
+        executor, plugin = _make_executor()
+        plugin.rpc.invoice.return_value = {
+            "payment_hash": "abc123",
+            "bolt11": "lnbc...",
+        }
+
+        class RPCError(Exception):
+            def __init__(self):
+                self.error = {
+                    "data": {
+                        "erring_channel": "555x5x5",
+                        # No erring_direction
+                        "failcodename": "WIRE_TEMPORARY_CHANNEL_FAILURE",
+                    }
+                }
+
+        plugin.rpc.waitsendpay.side_effect = RPCError()
+
+        result = executor.execute(
+            route=_make_route(),
+            amount_sats=50_000,
+            source_channel_id="111x1x0",
+            dest_channel_id="222x2x0",
+            max_fee_sats=10,
+        )
+
+        assert result.excluded_channels == ["555x5x5"]
 
     def test_diagnostic_log_fires_on_bare_exception(self):
         """When waitsendpay raises a plain Exception with no .error attr,


### PR DESCRIPTION
Live nexus-01 reproduction 2026-04-10 18:54Z (after PR #80 unblocked executions and PR #81 wired the retry path): the first engine retry attempted to call getroute with exclude=['934667x311x8'] — a bare SCID — and CLN rejected it:

  exclude: should be short_channel_id_dir or node_id: invalid token
  (see logs for details)

Both CLN's getroute and askrene's update-channel require the canonical directional form 'scid/dir'. The executor was capturing erring_channel from the waitsendpay failure data but dropping erring_direction, so the retry hint was unusable.

Fix: combine the two fields into '{scid}/{direction}' when both are present. Fall back to bare SCID if direction is missing (older CLN or wrapped failures) — some downstream use is still better than none.

Tests (3 new in test_rebalance_executor_v2.py):
- test_retriable_failure_records_exclude now asserts directional form
- test_exclude_captures_directional_form_when_direction_present (uses the exact nexus-01 observed data: 934667x311x8, direction 0, WIRE_FEE_INSUFFICIENT)
- test_exclude_falls_back_to_bare_scid_when_direction_missing

Full suite: 1393 passing, same pre-existing test_hive_live_contract failure.