### PR TITLE
fix: default action on revenue-config and revenue-policy read paths

### DIFF
--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -3088,7 +3088,7 @@ def revenue_list_ignored(plugin: Plugin) -> Dict[str, Any]:
 # =============================================================================
 
 @plugin.method("revenue-policy")
-def revenue_policy(plugin: Plugin, action: str, peer_id: str = None,
+def revenue_policy(plugin: Plugin, action: str = "list", peer_id: str = None,
                    strategy: str = None, rebalance: str = None,
                    fee_ppm: int = None, tag: str = None,
                    fee_multiplier_min: float = None,
@@ -3541,7 +3541,13 @@ def revenue_hot_channel_protection_peers(plugin: Plugin, action: str = "list", p
 
 
 @plugin.method("revenue-config")
-def revenue_config(plugin: Plugin, action: str, key: str = None, value: str = None) -> Dict[str, Any]:
+def revenue_config(
+    plugin: Plugin,
+    action: str = "get",
+    key: str = None,
+    value: str = None,
+    **_unused: Any,
+) -> Dict[str, Any]:
     """
     Get or set runtime configuration (Dynamic Runtime Configuration).
     

--- a/tests/test_operator_surface.py
+++ b/tests/test_operator_surface.py
@@ -283,6 +283,49 @@ def test_revenue_config_allows_public_resets():
     assert "removed" in result["message"]
 
 
+def test_revenue_config_no_args_returns_public_config_dict():
+    """Caller invokes ``lightning-cli revenue-config`` (or HTTP equivalent
+    with empty params) and gets the public config snapshot back instead of
+    a TypeError. Regression guard for the 22 traceback reports observed on
+    nexus-01 between Feb-Apr 2026 from rune_id 17 hitting the action-based
+    API with empty params."""
+    mod = _load_operator_surface_module()
+
+    result = mod.revenue_config(mod.plugin)
+
+    assert "config" in result
+    assert result["config"]["paused"] is True
+    assert result["config"]["daily_budget_sats"] == 1200
+
+
+def test_revenue_config_swallows_unknown_kwargs_from_wrapped_form_body():
+    """Some HTTP clients form-encode a JSON body and end up dispatching the
+    method with a single unrecognized key like
+    ``{'{"action":"get"}': ''}``. The handler must accept and ignore
+    extra keys rather than 500-ing on TypeError. Regression guard for the
+    same nexus-01 traceback class as the no-args case."""
+    mod = _load_operator_surface_module()
+
+    result = mod.revenue_config(
+        mod.plugin,
+        **{'{"action":"get"}': ""},
+    )
+
+    assert "config" in result
+
+
+def test_revenue_policy_no_args_returns_policy_list():
+    """``revenue-policy`` with no action defaults to listing all policies
+    rather than raising TypeError. Mirrors the revenue-config defaulting
+    so external monitoring callers don't pollute the log on probe."""
+    mod = _load_policy_surface_module()
+    mod.policy_manager.list_policies.return_value = []
+
+    result = mod.revenue_policy(mod.plugin)
+
+    assert "policies" in result or result.get("count", 0) == 0
+
+
 def test_total_cost_budget_excludes_canonical_open_close_from_generic_spend():
     mod = load_plugin_module()
     mod.config = SimpleNamespace(


### PR DESCRIPTION
## Summary

External callers hitting clnrest produced 22 `TypeError: missing a required argument: 'action'` tracebacks on nexus-01 since Feb 3. Both `revenue-config` and `revenue-policy` declared `action` as a required positional parameter; pyln's `_bind_kwargs` failed before the handlers could run, so the caller got an opaque 500 and the log filled with stack traces.

Two distinct broken caller patterns showed up live:

1. **Empty params** `{}` — caller still expects the pre-action surface
2. **Form-encoded JSON body collapsed into a single key**: `{'{"action":"get"}': ''}` from rune_id 17

Fix: default `action='get'` for `revenue-config` and `action='list'` for `revenue-policy`. Both routes are existing read-only branches with no side effects, so no behavior change for correct callers; broken callers now get a useful response instead of a traceback. `revenue-config` also gets `**_unused` to swallow stray kwargs from the form-encoding bug. `revenue-policy` already had `**kwargs`.

## Test plan

- [x] New regression tests in `tests/test_operator_surface.py`:
  - `test_revenue_config_no_args_returns_public_config_dict`
  - `test_revenue_config_swallows_unknown_kwargs_from_wrapped_form_body`
  - `test_revenue_policy_no_args_returns_policy_list`
- [x] Full suite: 1449 pass, 4 skipped, 0 regressions
- [ ] Post-merge: verify no new `missing a required argument: 'action'` lines in `cln.log` after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)