### PR TITLE
perf(rebalance_hive_router): cycle-scoped askrene exclude-layer reuse

### DIFF
--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -269,12 +269,13 @@ class ThreadSafeRpcProxy:
             proxy_timeout = 30
             if config:
                 proxy_timeout = config.rpc_timeout_seconds
-            # If the caller supplies its own ``timeout`` kwarg (e.g.
-            # ``waitsendpay(timeout=60)``), extend the proxy's effective
-            # wait so we never cut a legitimately long call short. Adds a
-            # small grace period so the underlying method has time to
-            # settle before the proxy fires its own timeout.
-            user_timeout = kwargs.get("timeout")
+            # If the caller supplies its own ``timeout`` kwarg, extend the
+            # proxy's effective wait so we never cut a legitimately long
+            # call short. For methods that natively accept ``timeout`` (e.g.
+            # ``waitsendpay``) we leave it in kwargs; for callers that pass
+            # ``_proxy_timeout`` we strip it so it never reaches pyln.
+            proxy_only = kwargs.pop("_proxy_timeout", None)
+            user_timeout = proxy_only if proxy_only is not None else kwargs.get("timeout")
             if isinstance(user_timeout, (int, float)) and user_timeout > 0:
                 proxy_timeout = max(proxy_timeout, int(user_timeout) + 5)
             future = self._submit_main(fn, name, proxy_timeout, *args, **kwargs)
@@ -326,21 +327,27 @@ class ThreadSafeRpcProxy:
         future.add_done_callback(lambda _f: self._async_submit_slots.release())
         return True
 
-    def call(self, method_name: str, payload: Any = None, **kwargs):
-        timeout = 30
+    def call(self, method_name: str, payload: Any = None, *, timeout: Optional[float] = None, **kwargs):
+        proxy_timeout = 30
         if config:
-            timeout = config.rpc_timeout_seconds
+            proxy_timeout = config.rpc_timeout_seconds
+        # Callers (e.g. askrene-getroutes on a loaded node) can extend the
+        # proxy ceiling past ``config.rpc_timeout_seconds`` without changing
+        # it globally. The kwarg is consumed here and never reaches pyln,
+        # so CLN's JSON-RPC schema never sees an unknown ``timeout`` field.
+        if isinstance(timeout, (int, float)) and timeout > 0:
+            proxy_timeout = max(proxy_timeout, int(timeout) + 5)
         future = self._submit_main(
             self._rpc.call,
             method_name,
-            timeout,
+            proxy_timeout,
             method_name,
             payload if payload is not None else {},
         )
         try:
-            return future.result(timeout=timeout)
+            return future.result(timeout=proxy_timeout)
         except (TimeoutError, self._FuturesTimeoutError):
-            self._plugin.log(f"RPC timeout after {timeout}s on {method_name}", level="warn")
+            self._plugin.log(f"RPC timeout after {proxy_timeout}s on {method_name}", level="warn")
             raise RPCTimeoutError(method_name)
 
     def fire_and_forget(self, method_name: str, payload: Any = None):

--- a/modules/data_service.py
+++ b/modules/data_service.py
@@ -272,7 +272,15 @@ class DataService:
         return self._plugin.rpc.getroute(node_id, amount_msat, **kwargs)
 
     def get_routes(self, **kwargs) -> Dict:
-        """Multi-route search via askrene. Never cached."""
+        """Multi-route search via askrene. Never cached.
+
+        The optional ``timeout`` kwarg is consumed by the RPC proxy (to
+        extend the per-call proxy ceiling) and is stripped before the
+        payload reaches CLN so askrene's strict schema never rejects it.
+        """
+        timeout = kwargs.pop("timeout", None)
+        if timeout is not None:
+            return self._plugin.rpc.call("getroutes", kwargs, timeout=timeout)
         return self._plugin.rpc.call("getroutes", kwargs)
 
     # --- Payment lifecycle ---

--- a/modules/rebalance_engine_v2.py
+++ b/modules/rebalance_engine_v2.py
@@ -842,85 +842,137 @@ class RebalanceEngine:
         if plan.selected:
             router = self._cycle_router
             priced = []
-            for pair in plan.selected:
-                pair_key = self._pair_key(pair)
-                debug_pair = considered_lookup.get(pair_key)
-                cooldown = self._get_persisted_pair_cooldown(
-                    pair.source_channel_id, pair.dest_channel_id
-                )
-                if cooldown is not None:
-                    self._update_pair_score_decomposition(
-                        pair,
-                        rejection_reason="pair_cooldown",
-                        route_status="pair_cooldown",
+            hive_router = self._hive_router
+            if hive_router is not None:
+                hive_router.begin_cycle()
+            try:
+                for pair in plan.selected:
+                    pair_key = self._pair_key(pair)
+                    debug_pair = considered_lookup.get(pair_key)
+                    cooldown = self._get_persisted_pair_cooldown(
+                        pair.source_channel_id, pair.dest_channel_id
                     )
-                    if debug_pair is not None:
+                    if cooldown is not None:
                         self._update_pair_score_decomposition(
-                            debug_pair,
+                            pair,
                             rejection_reason="pair_cooldown",
                             route_status="pair_cooldown",
                         )
-                    plan.skipped.append(SkipRecord(
-                        channel_id=pair.dest_channel_id,
-                        reason="pair_cooldown",
-                        value_class="valuable",
-                        detail=(
-                            f"src={pair.source_channel_id} "
-                            f"kind={cooldown['failure_kind']} "
-                            f"count={cooldown['failure_count']} "
-                            f"cooldown_until={cooldown['cooldown_until']}"
-                        ),
-                    ))
-                    continue
-                route_result, route_label = self._route_pair(
-                    pair=pair,
-                    router=router,
-                    exclude=None,
-                )
-                if route_result.success:
-                    pair.route_cost_sats = route_result.route_cost_sats
-                    pair.route = route_result.route
-                    effective_budget = self._probability_adjusted_budget(
-                        pair.pair_budget_sats,
-                        getattr(route_result, "probability_ppm", 0),
+                        if debug_pair is not None:
+                            self._update_pair_score_decomposition(
+                                debug_pair,
+                                rejection_reason="pair_cooldown",
+                                route_status="pair_cooldown",
+                            )
+                        plan.skipped.append(SkipRecord(
+                            channel_id=pair.dest_channel_id,
+                            reason="pair_cooldown",
+                            value_class="valuable",
+                            detail=(
+                                f"src={pair.source_channel_id} "
+                                f"kind={cooldown['failure_kind']} "
+                                f"count={cooldown['failure_count']} "
+                                f"cooldown_until={cooldown['cooldown_until']}"
+                            ),
+                        ))
+                        continue
+                    route_result, route_label = self._route_pair(
+                        pair=pair,
+                        router=router,
+                        exclude=None,
                     )
-                    self._update_pair_score_decomposition(
-                        pair,
-                        probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
-                        route_cost_sats=route_result.route_cost_sats,
-                        effective_budget_sats=effective_budget,
-                        route_status="priced",
-                    )
-                    if debug_pair is not None:
-                        debug_pair.route_cost_sats = route_result.route_cost_sats
-                        debug_pair.route = route_result.route
+                    if route_result.success:
+                        pair.route_cost_sats = route_result.route_cost_sats
+                        pair.route = route_result.route
+                        effective_budget = self._probability_adjusted_budget(
+                            pair.pair_budget_sats,
+                            getattr(route_result, "probability_ppm", 0),
+                        )
                         self._update_pair_score_decomposition(
-                            debug_pair,
+                            pair,
                             probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
                             route_cost_sats=route_result.route_cost_sats,
                             effective_budget_sats=effective_budget,
                             route_status="priced",
                         )
-                    if route_result.route_cost_sats <= effective_budget:
-                        # Phase 4.3: do_nothing hard gate. A priced pair
-                        # whose final_score does not clear the configured
-                        # hold margin is rejected with an explicit reason
-                        # rather than silently picked.
-                        hold_margin_raw = getattr(cfg, "rebalance_hold_margin", 0.0)
-                        if isinstance(hold_margin_raw, (int, float)):
-                            hold_margin = float(hold_margin_raw)
+                        if debug_pair is not None:
+                            debug_pair.route_cost_sats = route_result.route_cost_sats
+                            debug_pair.route = route_result.route
+                            self._update_pair_score_decomposition(
+                                debug_pair,
+                                probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
+                                route_cost_sats=route_result.route_cost_sats,
+                                effective_budget_sats=effective_budget,
+                                route_status="priced",
+                            )
+                        if route_result.route_cost_sats <= effective_budget:
+                            # Phase 4.3: do_nothing hard gate. A priced pair
+                            # whose final_score does not clear the configured
+                            # hold margin is rejected with an explicit reason
+                            # rather than silently picked.
+                            hold_margin_raw = getattr(cfg, "rebalance_hold_margin", 0.0)
+                            if isinstance(hold_margin_raw, (int, float)):
+                                hold_margin = float(hold_margin_raw)
+                            else:
+                                hold_margin = 0.0
+                            decomp = pair.score_decomposition or {}
+                            final_score = float(decomp.get("final_score", 0.0) or 0.0)
+                            if hold_margin > 0.0 and final_score <= hold_margin:
+                                self._update_pair_score_decomposition(
+                                    pair,
+                                    probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
+                                    route_cost_sats=route_result.route_cost_sats,
+                                    effective_budget_sats=effective_budget,
+                                    rejection_reason="below_hold_margin",
+                                    route_status="below_hold_margin",
+                                )
+                                if debug_pair is not None:
+                                    self._update_pair_score_decomposition(
+                                        debug_pair,
+                                        probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
+                                        route_cost_sats=route_result.route_cost_sats,
+                                        effective_budget_sats=effective_budget,
+                                        rejection_reason="below_hold_margin",
+                                        route_status="below_hold_margin",
+                                    )
+                                self._audit.log_skip(
+                                    channel_id=pair.dest_channel_id,
+                                    reason="below_hold_margin",
+                                    value_class="valuable",
+                                    remaining_budget_sats=pair.pair_budget_sats,
+                                    detail=(
+                                        f"score={final_score:.4f} margin={hold_margin:.4f}"
+                                    ),
+                                    router=router_tag,
+                                )
+                                plan.skipped.append(SkipRecord(
+                                    channel_id=pair.dest_channel_id,
+                                    reason="below_hold_margin",
+                                    value_class="valuable",
+                                    detail=(
+                                        f"src={pair.source_channel_id} "
+                                        f"score={final_score:.4f} "
+                                        f"margin={hold_margin:.4f}"
+                                    ),
+                                ))
+                                continue
+                            priced.append(pair)
+                            self._audit.log_pick(
+                                pair.source_channel_id,
+                                pair.dest_channel_id,
+                                pair.amount_sats,
+                                route_result.route_cost_sats,
+                                pair.score,
+                                router=route_label,
+                            )
                         else:
-                            hold_margin = 0.0
-                        decomp = pair.score_decomposition or {}
-                        final_score = float(decomp.get("final_score", 0.0) or 0.0)
-                        if hold_margin > 0.0 and final_score <= hold_margin:
                             self._update_pair_score_decomposition(
                                 pair,
                                 probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
                                 route_cost_sats=route_result.route_cost_sats,
                                 effective_budget_sats=effective_budget,
-                                rejection_reason="below_hold_margin",
-                                route_status="below_hold_margin",
+                                rejection_reason="route_over_budget",
+                                route_status="route_over_budget",
                             )
                             if debug_pair is not None:
                                 self._update_pair_score_decomposition(
@@ -928,120 +980,76 @@ class RebalanceEngine:
                                     probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
                                     route_cost_sats=route_result.route_cost_sats,
                                     effective_budget_sats=effective_budget,
-                                    rejection_reason="below_hold_margin",
-                                    route_status="below_hold_margin",
+                                    rejection_reason="route_over_budget",
+                                    route_status="route_over_budget",
                                 )
-                            self._audit.log_skip(
+                            plan.skipped.append(SkipRecord(
                                 channel_id=pair.dest_channel_id,
-                                reason="below_hold_margin",
+                                reason="route_over_budget",
                                 value_class="valuable",
                                 remaining_budget_sats=pair.pair_budget_sats,
                                 detail=(
-                                    f"score={final_score:.4f} margin={hold_margin:.4f}"
-                                ),
-                                router=router_tag,
-                            )
-                            plan.skipped.append(SkipRecord(
-                                channel_id=pair.dest_channel_id,
-                                reason="below_hold_margin",
-                                value_class="valuable",
-                                detail=(
-                                    f"src={pair.source_channel_id} "
-                                    f"score={final_score:.4f} "
-                                    f"margin={hold_margin:.4f}"
+                                    f"route_cost={route_result.route_cost_sats} "
+                                    f"effective_budget={effective_budget} "
+                                    f"probability_ppm={getattr(route_result, 'probability_ppm', 0)}"
                                 ),
                             ))
-                            continue
-                        priced.append(pair)
-                        self._audit.log_pick(
-                            pair.source_channel_id,
-                            pair.dest_channel_id,
-                            pair.amount_sats,
-                            route_result.route_cost_sats,
-                            pair.score,
-                            router=route_label,
-                        )
                     else:
-                        self._update_pair_score_decomposition(
-                            pair,
-                            probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
-                            route_cost_sats=route_result.route_cost_sats,
-                            effective_budget_sats=effective_budget,
-                            rejection_reason="route_over_budget",
-                            route_status="route_over_budget",
+                        # Iter3: when askrene reports no route, sling uses the
+                        # same pathfinder so it would also fail. Skip with
+                        # reason='no_route' instead of submitting unpriced.
+                        # Defensive escape valve: allow_router_fallback=True
+                        # restores the legacy fallback_unpriced submit path
+                        # for non-fail-closed policies. Default is False.
+                        decision = self._route_decision_for_pair(pair)
+                        fail_closed = self._fail_closed_on_route_failure(decision)
+                        allow_fallback_raw = getattr(cfg, "allow_router_fallback", False)
+                        allow_fallback = (
+                            bool(allow_fallback_raw) and not fail_closed
                         )
-                        if debug_pair is not None:
+                        if allow_fallback:
+                            pair.route = None
+                            pair.route_cost_sats = pair.pair_budget_sats
                             self._update_pair_score_decomposition(
-                                debug_pair,
-                                probability_ppm=int(getattr(route_result, "probability_ppm", 0) or 0),
-                                route_cost_sats=route_result.route_cost_sats,
-                                effective_budget_sats=effective_budget,
-                                rejection_reason="route_over_budget",
-                                route_status="route_over_budget",
-                            )
-                        plan.skipped.append(SkipRecord(
-                            channel_id=pair.dest_channel_id,
-                            reason="route_over_budget",
-                            value_class="valuable",
-                            remaining_budget_sats=pair.pair_budget_sats,
-                            detail=(
-                                f"route_cost={route_result.route_cost_sats} "
-                                f"effective_budget={effective_budget} "
-                                f"probability_ppm={getattr(route_result, 'probability_ppm', 0)}"
-                            ),
-                        ))
-                else:
-                    # Iter3: when askrene reports no route, sling uses the
-                    # same pathfinder so it would also fail. Skip with
-                    # reason='no_route' instead of submitting unpriced.
-                    # Defensive escape valve: allow_router_fallback=True
-                    # restores the legacy fallback_unpriced submit path
-                    # for non-fail-closed policies. Default is False.
-                    decision = self._route_decision_for_pair(pair)
-                    fail_closed = self._fail_closed_on_route_failure(decision)
-                    allow_fallback_raw = getattr(cfg, "allow_router_fallback", False)
-                    allow_fallback = (
-                        bool(allow_fallback_raw) and not fail_closed
-                    )
-                    if allow_fallback:
-                        pair.route = None
-                        pair.route_cost_sats = pair.pair_budget_sats
-                        self._update_pair_score_decomposition(
-                            pair,
-                            route_cost_sats=pair.pair_budget_sats,
-                            effective_budget_sats=pair.pair_budget_sats,
-                            route_status="fallback_unpriced",
-                        )
-                        if debug_pair is not None:
-                            debug_pair.route = None
-                            debug_pair.route_cost_sats = pair.pair_budget_sats
-                            self._update_pair_score_decomposition(
-                                debug_pair,
+                                pair,
                                 route_cost_sats=pair.pair_budget_sats,
                                 effective_budget_sats=pair.pair_budget_sats,
                                 route_status="fallback_unpriced",
                             )
-                        priced.append(pair)
-                        continue
-                    self._update_pair_score_decomposition(
-                        pair,
-                        rejection_reason="no_route",
-                        route_status="no_route",
-                    )
-                    if debug_pair is not None:
+                            if debug_pair is not None:
+                                debug_pair.route = None
+                                debug_pair.route_cost_sats = pair.pair_budget_sats
+                                self._update_pair_score_decomposition(
+                                    debug_pair,
+                                    route_cost_sats=pair.pair_budget_sats,
+                                    effective_budget_sats=pair.pair_budget_sats,
+                                    route_status="fallback_unpriced",
+                                )
+                            priced.append(pair)
+                            continue
                         self._update_pair_score_decomposition(
-                            debug_pair,
+                            pair,
                             rejection_reason="no_route",
                             route_status="no_route",
                         )
-                    plan.skipped.append(SkipRecord(
-                        channel_id=pair.dest_channel_id,
-                        reason="no_route",
-                        value_class="valuable",
-                        remaining_budget_sats=pair.pair_budget_sats,
-                        detail=str(route_result.error or "router_no_route"),
-                    ))
-                    continue
+                        if debug_pair is not None:
+                            self._update_pair_score_decomposition(
+                                debug_pair,
+                                rejection_reason="no_route",
+                                route_status="no_route",
+                            )
+                        plan.skipped.append(SkipRecord(
+                            channel_id=pair.dest_channel_id,
+                            reason="no_route",
+                            value_class="valuable",
+                            remaining_budget_sats=pair.pair_budget_sats,
+                            detail=str(route_result.error or "router_no_route"),
+                        ))
+                        continue
+
+            finally:
+                if hive_router is not None:
+                    hive_router.end_cycle()
 
             plan.selected = priced
 
@@ -1517,33 +1525,40 @@ class RebalanceEngine:
         )
         pair.route_decision = getattr(candidate, "route_decision", None)
 
+        hive_router = self._hive_router
+        if hive_router is not None:
+            hive_router.begin_cycle()
         try:
-            route_result, route_label = self._route_pair(
-                pair=pair,
-                router=self._cycle_router,
-                exclude=None,
-            )
-        except Exception as e:
-            self._log(
-                f"Manual route pricing failed for {source_channel_id}->{dest_channel_id}: {e}",
-                level="info",
-            )
-            return ExecutionResult(
-                success=False,
-                error=f"route_pricing_failed: {e}",
-                amount_sats=amount_sats,
-                route_type="sling",
-            )
-        else:
-            if route_result.success:
-                pair.route_cost_sats = route_result.route_cost_sats
-                pair.route = route_result.route
-            else:
+            try:
+                route_result, route_label = self._route_pair(
+                    pair=pair,
+                    router=self._cycle_router,
+                    exclude=None,
+                )
+            except Exception as e:
                 self._log(
-                    f"Manual route pricing failed for {source_channel_id}->{dest_channel_id}: "
-                    f"{route_result.error or 'no_route'} ({route_label})",
+                    f"Manual route pricing failed for {source_channel_id}->{dest_channel_id}: {e}",
                     level="info",
                 )
+                return ExecutionResult(
+                    success=False,
+                    error=f"route_pricing_failed: {e}",
+                    amount_sats=amount_sats,
+                    route_type="sling",
+                )
+            else:
+                if route_result.success:
+                    pair.route_cost_sats = route_result.route_cost_sats
+                    pair.route = route_result.route
+                else:
+                    self._log(
+                        f"Manual route pricing failed for {source_channel_id}->{dest_channel_id}: "
+                        f"{route_result.error or 'no_route'} ({route_label})",
+                        level="info",
+                    )
+        finally:
+            if hive_router is not None:
+                hive_router.end_cycle()
 
         decision = self._route_decision_for_pair(pair)
         if route_result is not None and not route_result.success and self._fail_closed_on_route_failure(decision):

--- a/modules/rebalance_hive_router.py
+++ b/modules/rebalance_hive_router.py
@@ -8,6 +8,7 @@ policies.
 
 from __future__ import annotations
 
+import threading
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional
 
@@ -68,6 +69,44 @@ class RebalanceHiveRouter:
         self.hive_hints = hive_hints
         self.data_service = data_service
         self.log = log or (lambda _msg, _level="info": None)
+        # Cycle state is thread-local so a manual revenue-rebalance (on the
+        # RPC worker thread) can't tear down the background pricing cycle's
+        # layers, and vice versa.
+        self._thread_state = threading.local()
+
+    def _cycle_active(self) -> bool:
+        return bool(getattr(self._thread_state, "active", False))
+
+    def _cycle_layers_dict(self) -> Dict[frozenset, str]:
+        layers = getattr(self._thread_state, "layers", None)
+        if layers is None:
+            layers = {}
+            self._thread_state.layers = layers
+        return layers
+
+    def begin_cycle(self) -> None:
+        """Enter a pricing cycle that reuses exclude layers across calls.
+
+        Within a cycle, identical exclude sets share a single askrene layer,
+        turning N × (create + M disables + remove) RPCs into one such batch
+        per unique exclude set. end_cycle() tears them down.
+        """
+        self.end_cycle()
+        self._thread_state.active = True
+
+    def end_cycle(self) -> None:
+        layers = self._cycle_layers_dict()
+        to_remove = list(layers.values())
+        layers.clear()
+        self._thread_state.active = False
+        for layer_name in to_remove:
+            try:
+                self._remove_layer(layer_name)
+            except Exception as exc:
+                self._log(
+                    f"end_cycle remove_layer({layer_name}) failed: {exc}",
+                    level="debug",
+                )
 
     def _log(self, msg: str, level: str = "info") -> None:
         try:
@@ -124,10 +163,16 @@ class RebalanceHiveRouter:
         else:
             self.plugin.rpc.call("askrene-disable-node", {"layer": layer, "node": node})
 
+    GETROUTES_TIMEOUT_SEC = 30
+
     def _get_routes(self, **kwargs) -> Dict[str, Any]:
         if self.data_service is not None:
-            return self.data_service.get_routes(**kwargs)
-        return self.plugin.rpc.call("getroutes", kwargs)
+            return self.data_service.get_routes(
+                timeout=self.GETROUTES_TIMEOUT_SEC, **kwargs
+            )
+        return self.plugin.rpc.call(
+            "getroutes", kwargs, timeout=self.GETROUTES_TIMEOUT_SEC
+        )
 
     def _is_hive_member(self, peer_id: str) -> bool:
         try:
@@ -221,28 +266,55 @@ class RebalanceHiveRouter:
     def _is_node_exclude(entry: str) -> bool:
         return "/" not in entry and "x" not in entry and ":" not in entry
 
-    @contextmanager
-    def _exclude_layer(self, excludes: List[str]) -> Iterator[Optional[str]]:
-        if not excludes:
-            yield None
-            return
+    @staticmethod
+    def _normalize_exclude_entry(entry: Any) -> str:
+        return str(entry or "").strip().replace(":", "x")
 
+    def _build_exclude_layer(self, normalized_excludes: List[str]) -> str:
         type(self)._exclude_counter += 1
         layer_name = f"rebalance-exclude-{type(self)._exclude_counter}"
         try:
             self._create_layer(layer_name)
-            for entry in excludes:
-                normalized = str(entry or "").strip().replace(":", "x")
-                if not normalized:
+            for entry in normalized_excludes:
+                if self._is_node_exclude(entry):
+                    self._disable_node(layer_name, entry)
                     continue
-                if self._is_node_exclude(normalized):
-                    self._disable_node(layer_name, normalized)
-                    continue
-                if "/" in normalized:
-                    self._disable_channel(layer_name, normalized)
+                if "/" in entry:
+                    self._disable_channel(layer_name, entry)
                     continue
                 for direction in (0, 1):
-                    self._disable_channel(layer_name, f"{normalized}/{direction}")
+                    self._disable_channel(layer_name, f"{entry}/{direction}")
+        except Exception:
+            try:
+                self._remove_layer(layer_name)
+            except Exception:
+                pass
+            raise
+        return layer_name
+
+    @contextmanager
+    def _exclude_layer(self, excludes: List[str]) -> Iterator[Optional[str]]:
+        normalized = [
+            n for n in (self._normalize_exclude_entry(e) for e in excludes) if n
+        ]
+        if not normalized:
+            yield None
+            return
+
+        if self._cycle_active():
+            key = frozenset(normalized)
+            cycle_layers = self._cycle_layers_dict()
+            cached = cycle_layers.get(key)
+            if cached is not None:
+                yield cached
+                return
+            layer_name = self._build_exclude_layer(normalized)
+            cycle_layers[key] = layer_name
+            yield layer_name
+            return
+
+        layer_name = self._build_exclude_layer(normalized)
+        try:
             yield layer_name
         finally:
             try:

--- a/tests/test_rebalance_hive_router.py
+++ b/tests/test_rebalance_hive_router.py
@@ -343,3 +343,130 @@ def test_hive_router_retries_once_when_expansion_layers_rotate():
     second_layers = data_service.get_routes.call_args_list[1].kwargs["layers"]
     assert "revenue-local" in first_layers
     assert "revenue-local" not in second_layers
+
+
+def _two_source_channel_fixture(data_service: MagicMock) -> None:
+    """Wire data_service to expose two local channels so _fleet_local_excludes
+    produces a non-empty exclude set that must be layered in askrene."""
+    data_service.get_askrene_layers.return_value = {"layers": [
+        {"layer": "hive-fleet"},
+        {"layer": "revenue-local"},
+    ]}
+    data_service.get_peer_channels.side_effect = lambda peer_id=None: (
+        {
+            "channels": [
+                {
+                    "short_channel_id": "100x1x0",
+                    "peer_id": SRC_PEER,
+                    "state": "CHANNELD_NORMAL",
+                },
+                {
+                    "short_channel_id": "400x1x0",
+                    "peer_id": MID_PEER,
+                    "state": "CHANNELD_NORMAL",
+                },
+            ]
+        }
+        if peer_id is None
+        else {
+            "channels": [{
+                "short_channel_id": "200x1x0",
+                "peer_id": DST_PEER,
+                "updates": {"remote": {
+                    "fee_base_msat": 0,
+                    "fee_proportional_millionths": 0,
+                    "cltv_expiry_delta": 6,
+                }},
+            }]
+        }
+    )
+    data_service.get_configs.return_value = {
+        "configs": {"cltv-final": {"value_int": 18}}
+    }
+    data_service.get_routes.return_value = {
+        "probability_ppm": 990000,
+        "routes": [{
+            "probability_ppm": 990000,
+            "amount_msat": 100000000,
+            "path": [{
+                "short_channel_id_dir": "100x1x0/0",
+                "next_node_id": DST_PEER,
+                "amount_msat": 100000000,
+                "delay": 18,
+            }],
+        }],
+    }
+
+
+def test_hive_router_reuses_exclude_layer_within_cycle():
+    from modules.rebalance_hive_router import RebalanceHiveRouter
+
+    plugin = MagicMock()
+    data_service = MagicMock()
+    _two_source_channel_fixture(data_service)
+
+    router = RebalanceHiveRouter(
+        plugin=plugin,
+        our_node_id=OUR_ID,
+        hive_hints=FakeHiveHints({SRC_PEER, DST_PEER}),
+        data_service=data_service,
+        log=lambda m, l: None,
+    )
+
+    router.begin_cycle()
+    try:
+        router.price_pair(_pair(), _route_decision(RoutePolicy.HYBRID))
+        router.price_pair(_pair(), _route_decision(RoutePolicy.HYBRID))
+    finally:
+        router.end_cycle()
+
+    # Two price_pair calls with the same exclude set share one created layer.
+    assert data_service.askrene_create_layer.call_count == 1
+    # Disables happen once (on layer creation), not per price_pair call.
+    assert data_service.askrene_update_channel.call_count == 1
+    # end_cycle tears the shared layer down exactly once.
+    assert data_service.askrene_remove_layer.call_count == 1
+
+
+def test_hive_router_without_cycle_tears_down_each_call():
+    from modules.rebalance_hive_router import RebalanceHiveRouter
+
+    plugin = MagicMock()
+    data_service = MagicMock()
+    _two_source_channel_fixture(data_service)
+
+    router = RebalanceHiveRouter(
+        plugin=plugin,
+        our_node_id=OUR_ID,
+        hive_hints=FakeHiveHints({SRC_PEER, DST_PEER}),
+        data_service=data_service,
+        log=lambda m, l: None,
+    )
+
+    router.price_pair(_pair(), _route_decision(RoutePolicy.HYBRID))
+    router.price_pair(_pair(), _route_decision(RoutePolicy.HYBRID))
+
+    assert data_service.askrene_create_layer.call_count == 2
+    assert data_service.askrene_remove_layer.call_count == 2
+
+
+def test_hive_router_get_routes_passes_timeout():
+    from modules.rebalance_hive_router import RebalanceHiveRouter
+
+    plugin = MagicMock()
+    data_service = MagicMock()
+    _two_source_channel_fixture(data_service)
+
+    router = RebalanceHiveRouter(
+        plugin=plugin,
+        our_node_id=OUR_ID,
+        hive_hints=FakeHiveHints({SRC_PEER, DST_PEER}),
+        data_service=data_service,
+        log=lambda m, l: None,
+    )
+
+    router.price_pair(_pair(), _route_decision(RoutePolicy.HYBRID))
+
+    assert data_service.get_routes.call_args.kwargs.get("timeout") == (
+        RebalanceHiveRouter.GETROUTES_TIMEOUT_SEC
+    )


### PR DESCRIPTION
## Summary

Fleet route pricing used to create, populate, and tear down a fresh askrene exclude layer on every \`price_pair\` call — on a node with ~30 local channels and 10 candidates per cycle, that's ~300 sequential \`askrene-update-channel\` RPCs sharing the 15s proxy budget before the one \`getroutes\` call that matters, producing logs like:

\`\`\`
REBAL_SKIP channel=... reason=no_route router=v3 detail=no_fleet_route: RPC call failed: method: getroutes, payload: {}, error: RPC timeout for method: getroutes
\`\`\`

- **Router cycle reuse.** \`RebalanceHiveRouter\` gains thread-local \`begin_cycle\`/\`end_cycle\`. Inside a cycle, \`price_pair\` calls with the same exclude set share one askrene layer, collapsing N × (create + M disables + remove) into one such batch per unique source. \`find_candidates\` wraps its pricing loop and \`execute_candidate\` wraps its route-pricing step in \`try\`/\`finally\` so layers tear down even on error. Thread-local state prevents a manual \`revenue-rebalance\` (RPC worker thread) from tearing down layers in use by the background pricing cycle.
- **Per-call timeout, no payload leak.** \`ThreadSafeRpcProxy.call\` now accepts a keyword-only \`timeout\` that extends the per-call proxy ceiling without leaking into the JSON-RPC payload. The \`__getattr__\` wrapper also gained an opt-in \`_proxy_timeout\` variant (pop-based) for callers that must use attribute-style access. \`data_service.get_routes\` threads a 30s ceiling through the \`.call(…, timeout=…)\` path so askrene has room on its one slow RPC without raising the global \`rpc_timeout_seconds\` default.
- **Three new tests** in \`tests/test_rebalance_hive_router.py\`: cycle-reuse shares one layer across calls, no-cycle path still tears down per call, and the 30s timeout kwarg lands on \`get_routes\`.

## Per-cycle RPC cost (10 pairs × ~30 local channels)

|                      | \`askrene-create-layer\` | \`askrene-update-channel\` | \`askrene-remove-layer\` | \`getroutes\` |
| -------------------- | ----------------------: | -------------------------: | -----------------------: | ------------: |
| before               |                      10 |                       ~290 |                       10 |            10 |
| after (same source)  |                       1 |                        ~29 |                        1 |            10 |

## Test plan

- [x] \`pytest tests/test_rebalance_hive_router.py\` — 8 passed (incl. 3 new)
- [x] \`pytest tests/test_data_service.py tests/test_rebalance_engine_v2.py tests/test_rebalancer_module.py tests/test_rpc_proxy_timeout_collision.py tests/test_plugin_audit_regressions.py tests/test_router_v3_engine.py tests/test_probability_aware_budget.py tests/test_pair_futility.py\` — 195 passed
- [x] Full suite: +2 passed, +0 regressions vs \`origin/main\` baseline on tracked tests (the pre-existing \`test_rebalance_orchestrator_v2\` failures are unchanged and orthogonal)
- [ ] Validate on a live node that \`REBAL_SKIP reason=no_route … getroutes timeout\` occurrences drop and that \`askrene-update-channel\` traffic is substantially lower per cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)