### PR TITLE
feat(rebalancer): reserved slots for coordination pairs above max_pairs cap

### DIFF
--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -519,6 +519,19 @@ plugin.add_option(
 )
 
 plugin.add_option(
+    name='revenue-ops-rebalance-coordination-reserved-slots',
+    default='2',
+    description=(
+        "Reserved slots for coordination pairs (from cl-hive's rebalance_"
+        "recommendations / rebalance_campaigns hints) on top of the "
+        "planner's max_pairs cap. Default 2 lets a small number of "
+        "hive-blessed pairs bypass the cap without letting coordination "
+        "dominate arbitrarily. Set to 0 to restore strict-cap behavior "
+        "(coordination competes inside max_pairs)."
+    )
+)
+
+plugin.add_option(
     name='revenue-ops-allow-router-fallback',
     default='false',
     description='When true, MARKET_ONLY/HYBRID pairs whose router cannot find a route are still submitted to sling unpriced (legacy fallback_unpriced). Default false; flip true only if production askrene is more pessimistic than sling (Iter3 escape valve).'
@@ -1417,6 +1430,9 @@ def init(options: Dict[str, Any], configuration: Dict[str, Any], plugin: Plugin,
         ),
         pair_fee_cap_ppm=_safe_int_opt(
             'revenue-ops-pair-fee-cap-ppm', '1000'
+        ),
+        rebalance_coordination_reserved_slots=_safe_int_opt(
+            'revenue-ops-rebalance-coordination-reserved-slots', '2'
         ),
         allow_router_fallback=options.get(
             'revenue-ops-allow-router-fallback', 'false'

--- a/modules/config.py
+++ b/modules/config.py
@@ -97,6 +97,7 @@ CONFIG_FIELD_TYPES: Dict[str, type] = {
     'hive_equalization_high_pct': float,
     'hive_equalization_cooldown_hours': int,
     'hive_equalization_max_candidates_per_cycle': int,
+    'rebalance_coordination_reserved_slots': int,
     'hive_push_enabled': bool,
     'hive_push_trigger_ratio': float,
     'hive_push_target_ratio': float,
@@ -235,6 +236,7 @@ CONFIG_FIELD_RANGES: Dict[str, tuple] = {
     'hive_equalization_high_pct': (0.0, 1.0),
     'hive_equalization_cooldown_hours': (1, 168),
     'hive_equalization_max_candidates_per_cycle': (1, 10),
+    'rebalance_coordination_reserved_slots': (0, 10),
     'futility_cooldown_hours': (1, 168),
     'target_flow': (1000, 100000000),
     'estimated_open_cost_sats': (0, 1000000),
@@ -371,6 +373,19 @@ class Config:
     hive_push_enabled: bool = True            # Deploy capital to fleet member channels
     hive_push_trigger_ratio: float = 0.60     # Push when local ratio exceeds this
     hive_push_target_ratio: float = 0.50      # Push balance toward this ratio
+
+    # Reserved slots for coordination pairs on top of the planner's
+    # max_pairs cap (Phase B.f, 2026-04-23). cl-hive publishes
+    # rebalance_recommendations / rebalance_campaigns via hive-export-hints,
+    # and the documented contract is that those pairs should "materialize
+    # before the normal pair cap is applied." Before this default, they
+    # competed for the planner's 10-slot cap and could be squeezed out
+    # entirely by a crop of EV-positive planner pairs. Default 2 lets up
+    # to two hive-blessed coordination pairs bypass the normal cap without
+    # letting coordination dominate arbitrarily. Set to 0 to restore the
+    # strict-cap behavior.
+    rebalance_coordination_reserved_slots: int = 2
+
     futility_cooldown_hours: int = 48   # Hours before retrying after 10+ consecutive failures
     inbound_fee_estimate_ppm: int = 50  # Route cost buffer added on top of last-hop fee (PPM)
     
@@ -785,6 +800,7 @@ class ConfigSnapshot:
     hive_push_enabled: bool
     hive_push_trigger_ratio: float
     hive_push_target_ratio: float
+    rebalance_coordination_reserved_slots: int
     futility_cooldown_hours: int
     inbound_fee_estimate_ppm: int
 

--- a/modules/rebalance_coordination_overlay.py
+++ b/modules/rebalance_coordination_overlay.py
@@ -346,13 +346,35 @@ def merge_coordination_pairs(
     overlay_pairs: Iterable[PairCandidate],
     *,
     max_pairs: int,
+    coordination_reserved_slots: int = 0,
 ) -> List[PairCandidate]:
+    """Merge planner-selected pairs with coordination overlay pairs.
+
+    Coordination overlay pairs (built from hive-export-hints'
+    rebalance_recommendations / rebalance_campaigns) are admitted first,
+    sorted by priority. Planner pairs fill any remaining room.
+
+    When `coordination_reserved_slots > 0`, coordination pairs may consume
+    up to `max_pairs + coordination_reserved_slots` total slots; planner
+    pairs still respect `max_pairs` strictly. This honors the
+    hive-export-hints contract that coordination candidates "materialize
+    before the normal pair cap is applied" — a small reserve keeps hive-
+    blessed work from being squeezed out by a crop of EV-positive planner
+    pairs, without letting coordination dominate arbitrarily. Default 0
+    preserves pre-Phase-B.f behavior (strict cap, coordination competes
+    against planner pairs within it).
+    """
+    reserved = max(0, coordination_reserved_slots)
+
     selected: list[PairCandidate] = []
     seen_pairs: set[tuple[str, str]] = set()
     used_sources: set[str] = set()
     used_dests: set[str] = set()
+    coord_count = 0
+    plan_count = 0
 
-    def add_pair(pair: PairCandidate) -> bool:
+    def add_pair(pair: PairCandidate, is_coord: bool) -> bool:
+        nonlocal coord_count, plan_count
         key = _pair_key(pair)
         if key in seen_pairs:
             for existing in selected:
@@ -375,12 +397,27 @@ def merge_coordination_pairs(
             return False
         if pair.source_channel_id in used_sources or pair.dest_channel_id in used_dests:
             return False
-        if len(selected) >= max_pairs:
-            return False
+        # Capacity check. Coord pairs have access to `reserved` slots on top
+        # of max_pairs; additional coord pairs compete in the planner pool.
+        # Plan pairs only see the planner pool (after any overflow coord).
+        if is_coord:
+            if coord_count >= reserved:
+                # Overflow — compete in the shared planner pool.
+                coord_overflow = coord_count - reserved
+                if coord_overflow + plan_count >= max_pairs:
+                    return False
+        else:
+            coord_overflow = max(0, coord_count - reserved)
+            if coord_overflow + plan_count >= max_pairs:
+                return False
         selected.append(pair)
         seen_pairs.add(key)
         used_sources.add(pair.source_channel_id)
         used_dests.add(pair.dest_channel_id)
+        if is_coord:
+            coord_count += 1
+        else:
+            plan_count += 1
         return True
 
     overlay_sorted = sorted(
@@ -396,10 +433,10 @@ def merge_coordination_pairs(
     )
 
     for pair in overlay_sorted:
-        add_pair(pair)
+        add_pair(pair, is_coord=True)
 
     for pair in plan.selected:
-        if add_pair(pair):
+        if add_pair(pair, is_coord=False):
             continue
         if _pair_key(pair) in seen_pairs:
             continue

--- a/modules/rebalance_engine_v2.py
+++ b/modules/rebalance_engine_v2.py
@@ -792,10 +792,12 @@ class RebalanceEngine:
         planner_max_pairs = getattr(planner, "max_pairs", 10)
         if not isinstance(planner_max_pairs, int) or planner_max_pairs <= 0:
             planner_max_pairs = 10
+        reserved = int(getattr(cfg, "rebalance_coordination_reserved_slots", 0) or 0)
         plan.selected = merge_coordination_pairs(
             plan,
             overlay.selected,
             max_pairs=planner_max_pairs,
+            coordination_reserved_slots=reserved,
         )
         if not plan.selected:
             hive_equalization = self._hive_equalization_overlay(

--- a/tests/test_rebalance_coordination_overlay.py
+++ b/tests/test_rebalance_coordination_overlay.py
@@ -201,3 +201,124 @@ def test_overlay_applies_segment_score_bias_to_coordinated_pair():
 
     assert len(candidates) == 1
     assert candidates[0].score > 250_000
+
+
+# -----------------------------------------------------------------------------
+# Phase B.f (2026-04-23): reserved coordination slots bypass max_pairs cap.
+# -----------------------------------------------------------------------------
+
+def _plain_pair(src: str, dst: str, score: float = 10.0) -> PairCandidate:
+    """Build a non-coordinated planner pair for cap-boundary tests."""
+    return PairCandidate(
+        source_channel_id=src,
+        dest_channel_id=dst,
+        source_peer_id="02" + (src * 64)[:64],
+        dest_peer_id="02" + (dst * 64)[:64],
+        amount_sats=100_000,
+        pair_budget_sats=50,
+        score=score,
+    )
+
+
+def _coordination_pair(idx: int) -> PairCandidate:
+    """Build a coordination pair with unique src/dst so dedup doesn't fire."""
+    return PairCandidate(
+        source_channel_id=f"9{idx}0x1x0",
+        dest_channel_id=f"8{idx}0x1x0",
+        source_peer_id="02" + f"c{idx}" + "0" * 60,
+        dest_peer_id="02" + f"d{idx}" + "0" * 60,
+        amount_sats=100_000,
+        pair_budget_sats=50,
+        score=0.1,
+        reason_code="coordinated_rebalance",
+        coordination_hint_type="recommendation",
+        coordination_hint_id=f"rec-{idx}",
+        coordination_rank_bonus=90.0,
+    )
+
+
+def test_reserved_slots_zero_preserves_strict_cap():
+    """Default (0 reserved) keeps the pre-Phase-B.f semantics: planner pairs
+    can occupy the full max_pairs slots; coordination pairs displace planner
+    pairs rather than bypassing the cap."""
+    from modules.rebalance_coordination_overlay import merge_coordination_pairs
+
+    plan = PlanResult(
+        selected=[_plain_pair("p1", "q1"), _plain_pair("p2", "q2")],
+        skipped=[],
+    )
+    coord = [_coordination_pair(1), _coordination_pair(2)]
+
+    selected = merge_coordination_pairs(
+        plan, coord, max_pairs=2, coordination_reserved_slots=0
+    )
+    # 2 coordination pairs fill the 2-slot cap; both planner pairs displaced.
+    assert len(selected) == 2
+    assert all(p.coordination_hint_id for p in selected)
+
+
+def test_reserved_slots_let_coordination_bypass_cap():
+    """Phase B.f: with reserved=2 and max_pairs=2, two coordination pairs
+    bypass the cap; planner pairs can still fill the base cap."""
+    from modules.rebalance_coordination_overlay import merge_coordination_pairs
+
+    plan = PlanResult(
+        selected=[_plain_pair("p1", "q1"), _plain_pair("p2", "q2")],
+        skipped=[],
+    )
+    coord = [_coordination_pair(1), _coordination_pair(2)]
+
+    selected = merge_coordination_pairs(
+        plan, coord, max_pairs=2, coordination_reserved_slots=2
+    )
+    # Coordination uses 2 reserved slots (total 2); plan pairs fill 2 base
+    # slots -> 4 selected total (2 coord + 2 plan, no collisions).
+    assert len(selected) == 4
+    coord_ids = {p.coordination_hint_id for p in selected if p.coordination_hint_id}
+    assert coord_ids == {"rec-1", "rec-2"}
+
+
+def test_plan_pairs_still_respect_max_pairs_when_reserved_unused():
+    """If the overlay has no coordination pairs, the reserved slots stay
+    idle — planner pairs cannot expand into them."""
+    from modules.rebalance_coordination_overlay import merge_coordination_pairs
+
+    plan = PlanResult(
+        selected=[
+            _plain_pair("p1", "q1"),
+            _plain_pair("p2", "q2"),
+            _plain_pair("p3", "q3"),
+        ],
+        skipped=[],
+    )
+
+    selected = merge_coordination_pairs(
+        plan, [], max_pairs=2, coordination_reserved_slots=2
+    )
+    # No coordination pairs; plan respects max_pairs=2 only.
+    assert len(selected) == 2
+
+
+def test_coordination_cannot_exceed_reserved_plus_max():
+    """10 coordination pairs with reserved=2 and max_pairs=3 admit at most 5."""
+    from modules.rebalance_coordination_overlay import merge_coordination_pairs
+
+    plan = PlanResult(selected=[], skipped=[])
+    coord = [_coordination_pair(i) for i in range(10)]
+
+    selected = merge_coordination_pairs(
+        plan, coord, max_pairs=3, coordination_reserved_slots=2
+    )
+    assert len(selected) == 5
+
+
+def test_negative_reserved_clamped_to_zero():
+    """Defensive: a misconfigured negative value doesn't inflate the cap."""
+    from modules.rebalance_coordination_overlay import merge_coordination_pairs
+
+    plan = PlanResult(selected=[_plain_pair("p1", "q1")], skipped=[])
+    selected = merge_coordination_pairs(
+        plan, [], max_pairs=2, coordination_reserved_slots=-5
+    )
+    # Negative clamps to 0; no change vs the default.
+    assert len(selected) == 1


### PR DESCRIPTION
## Summary

Honors the documented hive-export-hints contract that coordination
pairs "may materialize before the normal pair cap is applied." Before
this change, coordination pairs competed for the planner's `max_pairs`
cap and could be fully squeezed out by a crop of EV-positive planner
pairs.

## Audit context

An audit of the rebalance coordination overlay (2026-04-23) found:
- ✅ `hive_hints` exposes `get_rebalance_recommendations`,
  `get_rebalance_campaigns`, `get_route_segment_leases`
- ✅ Overlay construction and lease-based suppression work correctly
- ❌ `merge_coordination_pairs` enforced the same cap on coordination
  and planner pairs — contract violation

## Change

New kwarg `coordination_reserved_slots` (default 0, preserves prior
behavior):
- Coordination pairs get access to `reserved` slots above `max_pairs`
- Additional coordination pairs compete in the shared planner pool
- Planner pairs only see the planner pool
- Max total = `max_pairs + reserved`

New config field `rebalance_coordination_reserved_slots: int = 2`
(plugin option `revenue-ops-rebalance-coordination-reserved-slots`);
default 2 activates the fix.

## Test plan

- [x] `test_reserved_slots_zero_preserves_strict_cap` — legacy behavior
- [x] `test_reserved_slots_let_coordination_bypass_cap` — the bypass itself
- [x] `test_plan_pairs_still_respect_max_pairs_when_reserved_unused` — unused slots stay idle
- [x] `test_coordination_cannot_exceed_reserved_plus_max` — hard ceiling at 10 coord / (3+2) cap
- [x] `test_negative_reserved_clamped_to_zero` — defensive
- [x] 10/10 tests in `test_rebalance_coordination_overlay.py` pass
- [x] 257/257 tests pass across rebalance + planner + fee-controller

## Out of scope

No change to how coordination pairs are sorted, scored, or constructed.
No change to lease suppression or overlay construction. This PR only
widens the admission cap for coordination pairs; everything downstream
stays identical.

Independent of PR #87 (fee-controller overhaul) and PR #88
(capacity_planner dynamic close cost). Based on `origin/main` directly
and applies cleanly on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)