### PR TITLE
Reduce router-v3 layer probe log noise

### DIFF
--- a/modules/rebalance_router_v3.py
+++ b/modules/rebalance_router_v3.py
@@ -239,12 +239,14 @@ class RebalanceRouterV3:
         found = [name for name in requested if name in live_names]
         missing = [name for name in requested if name not in live_names]
 
-        msg = (
-            f"[router-v3] requested layers={requested} found={found}"
-        )
+        msg = f"[router-v3] requested layers={requested} found={found}"
         if missing:
             msg += f" missing={missing}"
-        self.log(msg, "info")
+        # price_pair re-probes layers on every route attempt so hive layers can
+        # appear without restarting the plugin. Healthy probes, including the
+        # explicit market-only override requested=[], should not spam operator
+        # logs at info level.
+        self.log(msg, "info" if missing else "debug")
         return found
 
     # ------------------------------------------------------------------

--- a/tests/test_rebalance_router_v3.py
+++ b/tests/test_rebalance_router_v3.py
@@ -79,6 +79,25 @@ def test_v3_router_records_found_and_missing_layers():
     assert "hive-reputation" in log_text
 
 
+def test_v3_router_empty_layer_override_logs_debug_not_info():
+    from modules.rebalance_router_v3 import RebalanceRouterV3
+    plugin = MagicMock()
+    plugin.rpc.call.return_value = {"layers": []}
+    logs = []
+    r = RebalanceRouterV3(
+        plugin=plugin,
+        our_node_id="03" + "a" * 64,
+        layer_names=["hive-fleet"],
+        log=lambda m, l: logs.append((l, m)),
+    )
+
+    logs.clear()
+    assert r._probe_layers([], include_observed_liquidity=False) == []
+
+    assert any(level == "debug" and "requested layers=[] found=[]" in msg for level, msg in logs)
+    assert not any(level == "info" and "requested layers=[] found=[]" in msg for level, msg in logs)
+
+
 def test_v3_router_includes_live_observed_liquidity_layer_when_present():
     plugin = MagicMock()
     data_service = MagicMock()


### PR DESCRIPTION
## Summary
- Downgrade healthy router-v3 askrene layer probe logs to debug
- Keep missing-layer probes at info so operator diagnostics remain visible
- Add regression coverage for explicit empty market-only layer probes

## Tests
- python3 -m pytest tests/test_rebalance_router_v3.py tests/test_rebalance_engine_v2.py tests/test_hive_discovery.py tests/test_fee_hive_bias.py