### PR TITLE
feat(fees): add quiescent Python authority handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The wire contracts are versioned and language-neutral: see [`schemas/`](schemas/
 - Live rebalances execute through `RebalanceEngineV2` using native explicit-route execution; route discovery is pinned to the `v3`/askrene router path.
 - There is no Sling dependency.
 - The normal runtime controls are `paused`, `daily_budget_sats`, fee rails, `authority_level` (what the node MAY do: `observe` < `fees` < `liquidity` < `capital`), `risk_profile` (coherent economic-risk defaults: `preserve`/`conservative`/`balanced`/`growth`/`custom`; preview any change with `revenue-profile-preview` before activating), and planner execution caps. (`fee_market_boundary_*` and `rebalance_min_profit` are deprecated no-ops scheduled for removal after the announced 2026-08-12 compatibility window — see `docs/refactor/phase0/contract-compatibility-policy.md`.)
+- Python fee authority is default-on and is controlled through Core Lightning's dynamic `revenue-ops-fee-authority-enabled` option, not `revenue-config`. Inspect it with `revenue-fee-authority-status`; follow the [Python fee-authority handoff runbook](docs/runbooks/python-fee-authority-handoff.md) for transient checks, a separately approved manual cutover, and rollback.
 - The primary operator surfaces are `revenue-status`, `revenue-fee-debug`, and `revenue-rebalance-debug`.
 - The normal workflow is decision explainability first, knob tuning second.
 - Auto fee bands are enabled by default. Manual policy bands are fallback only when an auto band is not yet available.

--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -35,6 +35,7 @@ from pyln.client import Plugin, RpcError
 from modules.flow_analysis import FlowAnalyzer, ChannelState
 from modules import flow_analysis as flow_analysis_mod
 from modules.fee_controller import FeeController
+from modules.fee_authority import FeeAuthorityGate
 from modules.rebalancer import EVRebalancer
 from modules.config import Config
 from modules.growth_budget import compute_growth_budget_status
@@ -1005,6 +1006,7 @@ class ThreadSafePluginProxy:
 # Global instances (initialized in init)
 flow_analyzer: Optional[FlowAnalyzer] = None
 fee_controller: Optional[FeeController] = None
+fee_authority_gate = FeeAuthorityGate()
 rebalancer: Optional[EVRebalancer] = None
 database: Optional[Database] = None
 config: Optional[Config] = None
@@ -1086,6 +1088,25 @@ def _parse_dynamic_bool(option_name: str, value: Any) -> bool:
     raise ValueError(f"{option_name} must be a boolean")
 
 
+def _on_fee_authority_change(
+    plugin_: Plugin,
+    option_name: str,
+    new_value: Any,
+) -> str:
+    """Atomically apply the dynamic Python fee-authority setting."""
+    enabled = _parse_dynamic_bool(option_name, new_value)
+    cfg = globals().get("config")
+    if cfg is None:
+        raise ValueError("fee authority configuration is not initialized")
+    with cfg._lock:
+        cfg.fee_authority_enabled = enabled
+        status = fee_authority_gate.set_enabled(enabled, reason="setconfig")
+    return (
+        f"{option_name}={str(status.enabled).lower()} "
+        f"generation={status.generation}"
+    )
+
+
 def _on_fee_replay_capture_change(
     plugin_: Plugin,
     option_name: str,
@@ -1136,6 +1157,15 @@ plugin.add_option(
     name='revenue-ops-fee-interval',
     default='1800',
     description='Interval in seconds for fee adjustments (default: 30 min)'
+)
+
+plugin.add_option(
+    name="revenue-ops-fee-authority-enabled",
+    default=True,
+    description="Permit Python fee evaluation and setchannel authority",
+    opt_type="bool",
+    dynamic=True,
+    on_change=_on_fee_authority_change,
 )
 
 plugin.add_option(
@@ -2474,6 +2504,10 @@ def init(options: Dict[str, Any], configuration: Dict[str, Any], plugin: Plugin,
         flow_interval=_safe_int('revenue-ops-flow-interval'),
         fee_interval=_safe_int('revenue-ops-fee-interval'),
         rebalance_interval=_safe_int('revenue-ops-rebalance-interval'),
+        fee_authority_enabled=_parse_dynamic_bool(
+            "revenue-ops-fee-authority-enabled",
+            options.get("revenue-ops-fee-authority-enabled", True),
+        ),
         fee_replay_capture_enabled=(
             str(options.get(
                 'revenue-ops-fee-replay-capture-enabled',
@@ -2668,6 +2702,11 @@ def init(options: Dict[str, Any], configuration: Dict[str, Any], plugin: Plugin,
             level='warn'
         )
     config = Config(**{k: v for k, v in config_kwargs.items() if k in config_fields})
+    with config._lock:
+        fee_authority_gate.set_enabled(
+            config.fee_authority_enabled,
+            reason="init",
+        )
     
     plugin.log(f"Configuration loaded: "
                f"fee_range=[{config.min_fee_ppm}, {config.max_fee_ppm}], "
@@ -3754,6 +3793,20 @@ def revenue_rebalance_cycle(plugin: Plugin, max_candidates: int = 20) -> Dict[st
 # =============================================================================
 # RPC METHODS - Exposed to lightning-cli
 # =============================================================================
+
+
+@plugin.method("revenue-fee-authority-status")
+def revenue_fee_authority_status(plugin: Plugin) -> Dict[str, Any]:
+    """Return the current in-process Python fee-authority state."""
+    status = fee_authority_gate.snapshot()
+    return {
+        "schema": "revenue_ops_fee_authority/v1",
+        "enabled": status.enabled,
+        "generation": status.generation,
+        "transitioned_at": status.transitioned_at,
+        "observed_at": int(time.time()),
+        "reason": status.reason,
+    }
 
 
 @plugin.method("revenue-status")

--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -4496,20 +4496,22 @@ def revenue_fee_debug(plugin: Plugin) -> Dict[str, Any]:
 @plugin.method("revenue-fee-cycle")
 def revenue_fee_cycle(plugin: Plugin) -> Dict[str, Any]:
     """Run one fee adjustment cycle immediately."""
-    denial = _fee_authority_denial("revenue-fee-cycle")
-    if denial is not None:
+    with fee_authority_gate.execution_lease(
+        "revenue-fee-cycle"
+    ) as denial:
+        if denial is not None:
+            return {
+                "ok": False,
+                "adjusted_channels": 0,
+                "fee_debug": {},
+                **denial,
+            }
+        adjustments = run_fee_adjustment() or []
         return {
-            "ok": False,
-            "adjusted_channels": 0,
-            "fee_debug": {},
-            **denial,
+            "ok": True,
+            "adjusted_channels": len(adjustments),
+            "fee_debug": revenue_fee_debug(plugin),
         }
-    adjustments = run_fee_adjustment() or []
-    return {
-        "ok": True,
-        "adjusted_channels": len(adjustments),
-        "fee_debug": revenue_fee_debug(plugin),
-    }
 
 
 @plugin.method("revenue-analyze")
@@ -4553,22 +4555,24 @@ def revenue_wake_all(plugin: Plugin) -> Dict[str, Any]:
 
     Usage: lightning-cli revenue-wake-all
     """
-    denial = _fee_authority_denial("revenue-wake-all")
-    if denial is not None:
-        return {
-            "channels_woken": 0,
-            "message": "Fee authority disabled",
-            **denial,
-        }
-    if fee_controller is None:
-        return {"error": "Plugin not fully initialized"}
+    with fee_authority_gate.execution_lease(
+        "revenue-wake-all"
+    ) as denial:
+        if denial is not None:
+            return {
+                "channels_woken": 0,
+                "message": "Fee authority disabled",
+                **denial,
+            }
+        if fee_controller is None:
+            return {"error": "Plugin not fully initialized"}
 
-    woken = fee_controller.wake_all_sleeping_channels()
-    return {
-        "status": "ok",
-        "channels_woken": woken,
-        "message": f"Woke {woken} sleeping channel(s). They will be evaluated on the next fee cycle."
-    }
+        woken = fee_controller.wake_all_sleeping_channels()
+        return {
+            "status": "ok",
+            "channels_woken": woken,
+            "message": f"Woke {woken} sleeping channel(s). They will be evaluated on the next fee cycle."
+        }
 
 
 @plugin.method("revenue-capacity-report")

--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -1007,6 +1007,7 @@ class ThreadSafePluginProxy:
 flow_analyzer: Optional[FlowAnalyzer] = None
 fee_controller: Optional[FeeController] = None
 fee_authority_gate = FeeAuthorityGate()
+_fee_authority_transition_lock = threading.Lock()
 rebalancer: Optional[EVRebalancer] = None
 database: Optional[Database] = None
 config: Optional[Config] = None
@@ -1098,9 +1099,12 @@ def _on_fee_authority_change(
     cfg = globals().get("config")
     if cfg is None:
         raise ValueError("fee authority configuration is not initialized")
-    with cfg._lock:
-        cfg.fee_authority_enabled = enabled
+    # Do not hold Config._lock while draining fee work: an accepted cycle
+    # may need Config.snapshot() before releasing its authority lease.
+    with _fee_authority_transition_lock:
         status = fee_authority_gate.set_enabled(enabled, reason="setconfig")
+        with cfg._lock:
+            cfg.fee_authority_enabled = status.enabled
     return (
         f"{option_name}={str(status.enabled).lower()} "
         f"generation={status.generation}"
@@ -3647,14 +3651,21 @@ def _run_scheduled_fee_adjustment():
 
 
 def run_fee_adjustment():
+    """Run one complete Python fee cycle under the shared authority lease."""
+    with fee_authority_gate.execution_lease(
+        "fee_adjustment"
+    ) as denial:
+        if denial is not None:
+            return denial
+        return _run_fee_adjustment_authorized()
+
+
+def _run_fee_adjustment_authorized():
     """
     Module 2: DTS+PID Fee Controller (Dynamic Pricing)
 
     Adjust channel fees using DTS+PID optimization.
     """
-    denial = _fee_authority_denial("fee_adjustment")
-    if denial is not None:
-        return denial
     if fee_controller is None:
         plugin.log("Fee controller not initialized", level='error')
         return []
@@ -4706,17 +4717,34 @@ def revenue_planner_history(plugin: Plugin, limit: int = 20) -> Dict[str, Any]:
 
 @plugin.method("revenue-set-fee")
 def revenue_set_fee(plugin: Plugin, channel_id: str = None, fee_ppm: int = None, force: bool = False) -> Dict[str, Any]:
+    """Manually set a fee while holding the shared authority lease."""
+    with fee_authority_gate.execution_lease(
+        "revenue-set-fee"
+    ) as denial:
+        if denial is not None:
+            return {
+                "error": "Fee authority disabled",
+                **denial,
+            }
+        return _revenue_set_fee_authorized(
+            plugin,
+            channel_id=channel_id,
+            fee_ppm=fee_ppm,
+            force=force,
+        )
+
+
+def _revenue_set_fee_authorized(
+    plugin: Plugin,
+    channel_id: str = None,
+    fee_ppm: int = None,
+    force: bool = False,
+) -> Dict[str, Any]:
     """
     Manually set fee for a channel.
 
     Usage: lightning-cli revenue-set-fee channel_id fee_ppm [force=false]
     """
-    denial = _fee_authority_denial("revenue-set-fee")
-    if denial is not None:
-        return {
-            "error": "Fee authority disabled",
-            **denial,
-        }
     if channel_id is None or fee_ppm is None:
         return {"error": "usage: revenue-set-fee channel_id fee_ppm [force=false]"}
     if fee_controller is None or config is None:

--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -6876,7 +6876,11 @@ def _on_forward_event_impl(forward_event: Dict, plugin: Plugin, **kwargs):
     #     failure reason exists, and most such failures are liquidity
     #     failures that say nothing about our fee, so the nudge is DROPPED
     #     entirely — a misdirected systematic signal is worse than none.
-    if status in ("failed", "local_failed") and fee_controller is not None:
+    if (
+        status in ("failed", "local_failed")
+        and fee_controller is not None
+        and _fee_authority_denial("failed_forward_trigger") is None
+    ):
         out_scid = forward_event.get("out_channel")
         out_scid = normalize_scid(out_scid) if out_scid else None
         failcode = forward_event.get("failcode")

--- a/cl-revenue-ops.py
+++ b/cl-revenue-ops.py
@@ -1107,6 +1107,10 @@ def _on_fee_authority_change(
     )
 
 
+def _fee_authority_denial(operation: str) -> dict[str, object] | None:
+    return fee_authority_gate.deny_reason(operation)
+
+
 def _on_fee_replay_capture_change(
     plugin_: Plugin,
     option_name: str,
@@ -3000,6 +3004,7 @@ def init(options: Dict[str, Any], configuration: Dict[str, Any], plugin: Plugin,
         database,
         policy_manager,
         profitability_analyzer,
+        fee_authority_gate=fee_authority_gate,
     )
     # Phase 1 shadow (docs/planning/2026-07-12-refactor-phase1-wiring.md):
     # observe-mode intent recording + snapshot preview. Fail-open by
@@ -3215,7 +3220,7 @@ def init(options: Dict[str, Any], configuration: Dict[str, Any], plugin: Plugin,
                 if shutdown_event.wait(_LOOP_BACKOFF_SECONDS):
                     break
     
-    def fee_adjustment_loop():
+    def fee_adjustment_loop(scheduled_work=None):
         """Background loop for fee adjustment."""
         # Staggered startup: fees at 90s (was 60s) to avoid thundering herd
         if shutdown_event.wait(90):
@@ -3230,7 +3235,7 @@ def init(options: Dict[str, Any], configuration: Dict[str, Any], plugin: Plugin,
 
                 try:
                     plugin.log("Running scheduled fee adjustment...")
-                    run_fee_adjustment()
+                    (scheduled_work or run_fee_adjustment)()
                 except (RPCTimeoutError, RPCBreakerOpen) as e:
                     plugin.log(f"RPC degraded in fee adjustment: {e}. Skipping this cycle.", level='warn')
                 except Exception as e:
@@ -3577,7 +3582,12 @@ def init(options: Dict[str, Any], configuration: Dict[str, Any], plugin: Plugin,
 
     # Start background threads (daemon=True so they don't block shutdown)
     threading.Thread(target=flow_analysis_loop, daemon=True, name="flow-analysis").start()
-    threading.Thread(target=fee_adjustment_loop, daemon=True, name="fee-adjustment").start()
+    threading.Thread(
+        target=fee_adjustment_loop,
+        args=(_run_scheduled_fee_adjustment,),
+        daemon=True,
+        name="fee-adjustment",
+    ).start()
     threading.Thread(target=rebalance_check_loop, daemon=True, name="rebalance-check").start()
     threading.Thread(target=snapshot_peers_delayed, daemon=True, name="startup-snapshot").start()
     threading.Thread(target=financial_snapshot_loop, daemon=True, name="financial-snapshot").start()
@@ -3629,12 +3639,22 @@ def run_flow_analysis():
 
 
 
+def _run_scheduled_fee_adjustment():
+    denial = _fee_authority_denial("scheduled_fee_cycle")
+    if denial is not None:
+        return denial
+    return run_fee_adjustment()
+
+
 def run_fee_adjustment():
     """
     Module 2: DTS+PID Fee Controller (Dynamic Pricing)
 
     Adjust channel fees using DTS+PID optimization.
     """
+    denial = _fee_authority_denial("fee_adjustment")
+    if denial is not None:
+        return denial
     if fee_controller is None:
         plugin.log("Fee controller not initialized", level='error')
         return []
@@ -4465,6 +4485,14 @@ def revenue_fee_debug(plugin: Plugin) -> Dict[str, Any]:
 @plugin.method("revenue-fee-cycle")
 def revenue_fee_cycle(plugin: Plugin) -> Dict[str, Any]:
     """Run one fee adjustment cycle immediately."""
+    denial = _fee_authority_denial("revenue-fee-cycle")
+    if denial is not None:
+        return {
+            "ok": False,
+            "adjusted_channels": 0,
+            "fee_debug": {},
+            **denial,
+        }
     adjustments = run_fee_adjustment() or []
     return {
         "ok": True,
@@ -4514,6 +4542,13 @@ def revenue_wake_all(plugin: Plugin) -> Dict[str, Any]:
 
     Usage: lightning-cli revenue-wake-all
     """
+    denial = _fee_authority_denial("revenue-wake-all")
+    if denial is not None:
+        return {
+            "channels_woken": 0,
+            "message": "Fee authority disabled",
+            **denial,
+        }
     if fee_controller is None:
         return {"error": "Plugin not fully initialized"}
 
@@ -4676,6 +4711,12 @@ def revenue_set_fee(plugin: Plugin, channel_id: str = None, fee_ppm: int = None,
 
     Usage: lightning-cli revenue-set-fee channel_id fee_ppm [force=false]
     """
+    denial = _fee_authority_denial("revenue-set-fee")
+    if denial is not None:
+        return {
+            "error": "Fee authority disabled",
+            **denial,
+        }
     if channel_id is None or fee_ppm is None:
         return {"error": "usage: revenue-set-fee channel_id fee_ppm [force=false]"}
     if fee_controller is None or config is None:

--- a/docs/refactor/phase0/compatibility-catalog.md
+++ b/docs/refactor/phase0/compatibility-catalog.md
@@ -1,13 +1,14 @@
 # Public compatibility catalog (baseline 5e8f747)
 
 What the refactor MUST keep working (refactor invariants 2 and 3).
-Pin test: `tests/test_rpc_surface_inventory.py` (68 methods; 64 at baseline + econ-shadow diagnostics `revenue-econ-snapshot`, `revenue-econ-reconcile`, `revenue-econ-cycle` + risk-profile diagnostic `revenue-profile-preview` (PR 8, read-only), NO compatibility promise yet).
+Pin test: `tests/test_rpc_surface_inventory.py` (69 methods; 64 at baseline + econ-shadow diagnostics `revenue-econ-snapshot`, `revenue-econ-reconcile`, `revenue-econ-cycle` + risk-profile diagnostic `revenue-profile-preview` (PR 8, read-only) + Python fee-authority diagnostic `revenue-fee-authority-status`).
 
 ## RPC surface
 
 Primary operator surfaces (must remain schema-compatible; per
 refactor.md Workstream I these become facades over projections):
-`revenue-status`, `revenue-fee-debug`, `revenue-rebalance-debug`,
+`revenue-status`, `revenue-fee-authority-status`, `revenue-fee-debug`,
+`revenue-rebalance-debug`,
 `revenue-config get|set`, `revenue-profitability`, `revenue-analyze`,
 `revenue-wake-all`, `revenue-dashboard`, `revenue-health`,
 planner/Boltz/LN+ diagnostics.
@@ -18,7 +19,7 @@ Classification per method: `docs/audits/CL_REVENUE_OPS_ACTION_RPC_INVENTORY.md`
 (header refreshed 2026-07-09; body dated 2026-05-20 — refresh during
 Workstream I).
 
-Full 67-method list: `EXPECTED_RPC_METHODS` in the pin test is normative.
+Full 69-method list: `EXPECTED_RPC_METHODS` in the pin test is normative.
 
 ## Config surface
 

--- a/docs/refactor/phase0/compatibility-catalog.md
+++ b/docs/refactor/phase0/compatibility-catalog.md
@@ -23,11 +23,11 @@ Full 69-method list: `EXPECTED_RPC_METHODS` in the pin test is normative.
 
 ## Config surface
 
-Owner: `modules/config.py` — a single `Config` dataclass (142 fields)
+Owner: `modules/config.py` — a single `Config` dataclass (147 fields)
 plus the `config_overrides` table (`revenue-config set` persists
 overrides; precedence documented in README.md §revenue-config).
 
-- Runtime-settable keys: `PUBLIC_RUNTIME_KEYS` (59, listed below).
+- Runtime-settable keys: `PUBLIC_RUNTIME_KEYS` (62, listed below).
 - Immutable at runtime: `db_path`, `dry_run` (`IMMUTABLE_CONFIG_KEYS` —
   dry_run is immutable so enabling it cannot HIDE actions).
 - The refactor's Workstream I risk-profile work must preserve every
@@ -59,7 +59,7 @@ dataclass is normative).
 
 ---
 
-### Runtime-settable keys (PUBLIC_RUNTIME_KEYS, 59)
+### Runtime-settable keys (PUBLIC_RUNTIME_KEYS, 62)
 
 - `paused`
 - `daily_budget_sats`
@@ -107,7 +107,10 @@ dataclass is normative).
 - `econ_cycle_rebalance_enabled` (added 2026-07-13, Workstream H cutover)
 - `econ_cycle_planner_enabled` (added 2026-07-13, Workstream H cutover)
 - `econ_cycle_boltz_enabled` (added 2026-07-13, Workstream H cutover)
+- `econ_ev_populated` (added 2026-07-13, Phase E PR 6)
+- `econ_conflict_rules_extended` (added 2026-07-13, Phase G PR 10)
 - `authority_level` (added 2026-07-13, Phase 4 Workstream I; observe/fees/liquidity/capital, default `capital`)
+- `risk_profile` (added 2026-07-13, Phase D PR 7; default `custom`)
 - `lnplus_swaps_enabled`
 - `lnplus_execute_applications`
 - `lnplus_swap_preference_margin`
@@ -121,7 +124,7 @@ dataclass is normative).
 - `lnplus_inbound_credit_factor`
 - `lnplus_watcher_interval`
 
-### Full Config dataclass surface (142 fields with defaults)
+### Full Config dataclass surface (147 fields with defaults)
 
 | Field | Default | Runtime-settable |
 |---|---|---|
@@ -129,6 +132,8 @@ dataclass is normative).
 | `flow_interval` | `3600` |  |
 | `fee_interval` | `1800` |  |
 | `rebalance_interval` | `900` |  |
+| `fee_authority_enabled` | `True` |  |
+| `fee_replay_capture_enabled` | `False` |  |
 | `hot_channel_protection_enabled` | `True` |  |
 | `hot_channel_protection_override_peers` | `''` |  |
 | `hot_channel_protection_min_velocity` | `0.2` |  |
@@ -160,7 +165,10 @@ dataclass is normative).
 | `econ_cycle_rebalance_enabled` | `False` | yes |
 | `econ_cycle_planner_enabled` | `False` | yes |
 | `econ_cycle_boltz_enabled` | `False` | yes |
+| `econ_ev_populated` | `False` | yes |
+| `econ_conflict_rules_extended` | `False` | yes |
 | `authority_level` | `'capital'` | yes |
+| `risk_profile` | `'custom'` | yes |
 | `expansion_treasury_enabled` | `False` |  |
 | `expansion_treasury_onchain_target_sats` | `5000000` |  |
 | `expansion_treasury_min_deficit_sats` | `250000` |  |

--- a/docs/refactor/phase0/config-field-classification.md
+++ b/docs/refactor/phase0/config-field-classification.md
@@ -23,7 +23,7 @@ change.
 | `planner_max_fee_rate_sat_vb` | `50.0` |
 | `receivable_ratio_floor` | `0.2` |
 
-## authority_control (22) — What the node MAY do — pause, dry-run, authority level, capability gates
+## authority_control (23) — What the node MAY do — pause, dry-run, authority level, capability gates
 
 | Field | Default |
 |---|---|
@@ -42,6 +42,7 @@ change.
 | `econ_governor_rebalance_enabled` | `False` |
 | `econ_shadow_enabled` | `False` |
 | `expansion_treasury_enabled` | `False` |
+| `fee_authority_enabled` | `True` |
 | `lnplus_execute_applications` | `True` |
 | `lnplus_swaps_enabled` | `True` |
 | `paused` | `False` |

--- a/docs/runbooks/python-fee-authority-handoff.md
+++ b/docs/runbooks/python-fee-authority-handoff.md
@@ -84,36 +84,107 @@ Before cutover, require all of the following:
 3. The replacement remains verified observer/dry-run/no-broadcast.
 4. A fresh status read reports `enabled=true`.
 
-Only after separate operator approval, run the persistent change manually:
+Only after separate operator approval, run the persistent change manually and
+validate Core Lightning's nested response in the same command:
 
 ```bash
 lightning-cli setconfig \
-  config=revenue-ops-fee-authority-enabled val=false transient=false
+  config=revenue-ops-fee-authority-enabled val=false transient=false \
+  | jq -e '
+      .config.value_bool == false
+      and (.config.source | type == "string")
+      and (.config.source
+           | test("(^|/)config[.]setconfig:[1-9][0-9]*$"))
+    '
 ```
 
-Inspect the direct `setconfig` response before proceeding. Its returned source
-must be exactly `config.setconfig`, and its effective value must be `false`.
-Stop and roll back if either check fails. Then read
-`revenue-fee-authority-status` and require `enabled=false`, `reason=setconfig`,
-and the expected generation advance. Re-read status after the next scheduled fee
-interval to prove the timer obeyed the disabled gate and did not perform a
-transition.
+The response contract is nested under `.config`. The source is not the literal
+string `config.setconfig`; it is a basename or absolute path plus a positive
+line number. Live read-only evidence for another dynamic option was
+`/data/lightningd/bitcoin/config.setconfig:1`. The regular expression above
+accepts that path and `config.setconfig:1`, but rejects another basename,
+missing line suffix, line zero, or a non-boolean value.
+
+Then read `revenue-fee-authority-status` and require `enabled=false`,
+`reason=setconfig`, and the expected generation advance. Re-read status after
+the next scheduled fee interval to prove the timer obeyed the disabled gate and
+did not perform a transition.
 
 This cutover disables Python fee mutation authority only. It does not authorize
 broadcasts by the replacement.
 
-## Persistent rollback
+## Rollback boundaries
 
-If the cutover is aborted or verification fails, restore the durable default
-manually:
+### Pre-arm abort (pre-arm and pre-Rust-activation only)
+
+A short Python-only restore is allowed **pre-arm and pre-Rust-activation only**:
+no cutover arm has ever been installed for the candidate, Rust fee activation
+has never been attempted, Rust remains observer/dry-run/no-broadcast, and its
+mutation count is unchanged. Under those conditions only, restore and verify
+the persistent Python value:
 
 ```bash
 lightning-cli setconfig \
-  config=revenue-ops-fee-authority-enabled val=true transient=false
+  config=revenue-ops-fee-authority-enabled val=true transient=false \
+  | jq -e '
+      .config.value_bool == true
+      and (.config.source | type == "string")
+      and (.config.source
+           | test("(^|/)config[.]setconfig:[1-9][0-9]*$"))
+    '
 ```
 
-Inspect the direct response and require source `config.setconfig` with effective
-value `true`. Then require `revenue-fee-authority-status` to report
-`enabled=true`, `reason=setconfig`, and the expected generation advance. A
-temporary `transient=true` restore is not a substitute for persistent rollback
-after a persistent cutover.
+Then require `revenue-fee-authority-status` to report `enabled=true`,
+`reason=setconfig`, and the expected generation advance. A transient restore
+is not a substitute for this persistent rollback.
+
+### Post-activation rollback
+
+Once an arm has been installed or Rust fee activation has been attempted,
+never re-enable Python first. Use this order to prevent overlapping authority:
+
+1. Disable Rust fee broadcasts and positively verify the live executor cannot
+   begin another broadcast.
+2. Verify that no Rust fee batch is active; wait for or abort the batch through
+   the reviewed Rust operational interface.
+3. Remove the cutover arm and verify it is absent.
+4. Reconcile or quarantine every ambiguous Rust action before another
+   authority can act.
+5. Restore the checksummed prior Rust shadow artifact if required.
+6. Re-enable Python fee authority persistently and validate the nested
+   `.config.value_bool == true` and source-path contract with the exact
+   `jq -e` check from the pre-arm section.
+7. Require positive Python status `enabled=true`, then confirm Rust is
+   observer/dry-run/no-broadcast and its mutation count remains stable.
+8. Preserve the incident evidence and reset promotion status.
+
+Do not compress this sequence into the pre-arm shortcut merely because the
+rollback is urgent.
+
+## Reverting to source that does not register the option
+
+A persistent `config.setconfig` entry can prevent older source from loading if
+that source does not register `revenue-ops-fee-authority-enabled`. Prefer a
+rollback artifact that retains the dynamic option. If older source is required,
+the following is a manual pre-revert safety sequence and must not be automated:
+
+1. Complete the applicable rollback boundary above: Rust broadcasts disabled,
+   no batch active, arm absent, and every ambiguity reconciled or quarantined.
+2. While the current Python release is still loaded and still registers the
+   option, re-enable Python fee authority persistently and pass both the nested
+   `jq -e` response check and positive status readback.
+3. Use the returned source field to identify the resolved `config.setconfig` path.
+   Back it up with ownership, mode, and checksum recorded.
+4. Re-read that file immediately before editing, identify by option name rather
+   than trusting a possibly shifted line number, and remove exactly the active
+   `revenue-ops-fee-authority-enabled` entry with an operator-reviewed atomic
+   edit. Abort if the match is absent or ambiguous; preserve all unrelated
+   entries and original ownership/mode.
+5. Verify the persistent file no longer contains an active entry for the
+   option while the still-running plugin continues to report authority enabled.
+6. Only then revert to source that does not register the option and follow the
+   established checksummed plugin-only rollback procedure.
+
+Do not unload or replace the current plugin before step 5: it is the component
+that can positively prove Python authority is enabled while persistent cleanup
+is performed.

--- a/docs/runbooks/python-fee-authority-handoff.md
+++ b/docs/runbooks/python-fee-authority-handoff.md
@@ -14,10 +14,12 @@ approval after the reviewed source has been deployed and verified default-on.
   or grant broadcast permission anywhere else. The replacement must remain in
   observer/dry-run/no-broadcast mode unless a separate change authorizes more.
 - A disabled gate blocks scheduled and manual fee evaluation, manual fee
-  setting, wake requests, the final `setchannel` execution boundary,
-  failed-forward fee nudges, and policy-change wakeups. It does not stop
-  read-only status or policy inspection, settled-forward accounting, or the
-  observational replay-capture control.
+  setting, channel-open initial-fee handling, direct controller fee-evaluation
+  and direct controller wake boundaries, dynamic `htlcmax` updates, wake
+  requests, the final `setchannel` execution boundary, failed-forward fee
+  nudges, and policy-change wakeups. It does not stop read-only status or
+  policy inspection, settled-forward accounting, or the observational
+  replay-capture control.
 - Authority transitions are manual. Initialization adopts the configured value,
   and the dynamic `setconfig` callback applies operator changes. Timers never
   change authority; scheduled fee work only checks and obeys the gate.

--- a/docs/runbooks/python-fee-authority-handoff.md
+++ b/docs/runbooks/python-fee-authority-handoff.md
@@ -1,0 +1,119 @@
+# Python Fee Authority Handoff Runbook
+
+This runbook defines the operator contract for the Python fee-authority gate. It
+does not authorize a live handoff. A planned cutover requires separate operator
+approval after the reviewed source has been deployed and verified default-on.
+
+## Contract
+
+- `revenue-ops-fee-authority-enabled` is a dynamic Core Lightning option. It is
+  not a `revenue-config` database override.
+- Authority defaults to `true`. While enabled, the existing Python fee
+  evaluation and `setchannel` path remains authoritative.
+- Disabling authority does not start another implementation, restart a plugin,
+  or grant broadcast permission anywhere else. The replacement must remain in
+  observer/dry-run/no-broadcast mode unless a separate change authorizes more.
+- A disabled gate blocks scheduled and manual fee evaluation, manual fee
+  setting, wake requests, the final `setchannel` execution boundary,
+  failed-forward fee nudges, and policy-change wakeups. It does not stop
+  read-only status or policy inspection, settled-forward accounting, or the
+  observational replay-capture control.
+- Authority transitions are manual. Initialization adopts the configured value,
+  and the dynamic `setconfig` callback applies operator changes. Timers never
+  change authority; scheduled fee work only checks and obeys the gate.
+
+## Inspect authority
+
+Run this before and after every transition:
+
+```bash
+lightning-cli revenue-fee-authority-status
+```
+
+The response schema is `revenue_ops_fee_authority/v1`:
+
+- `enabled` is the current in-process gate value.
+- `generation` is an in-process transition counter. It advances only when the
+  effective boolean changes; repeating the current value is idempotent.
+- `transitioned_at` is the Unix timestamp of the latest effective transition.
+- `observed_at` is the status-read timestamp.
+- `reason` is `initial`, `init`, or `setconfig`, according to the transition
+  source inside the plugin.
+
+`generation` is process-local and must not be compared across plugin restarts.
+
+## Transient disable and restore
+
+These runtime-only commands are for a separately approved rehearsal or an
+explicitly temporary response. `transient=true` does not establish the durable
+live cutover state.
+
+Disable Python fee authority for the current runtime:
+
+```bash
+lightning-cli setconfig \
+  config=revenue-ops-fee-authority-enabled val=false transient=true
+```
+
+Immediately run `lightning-cli revenue-fee-authority-status` and require
+`enabled=false`, `reason=setconfig`, and a generation advance if the prior value
+was true.
+
+Restore Python fee authority for the current runtime:
+
+```bash
+lightning-cli setconfig \
+  config=revenue-ops-fee-authority-enabled val=true transient=true
+```
+
+Immediately run `lightning-cli revenue-fee-authority-status` and require
+`enabled=true`, `reason=setconfig`, and a generation advance if the prior value
+was false. Never leave a rehearsal disabled.
+
+## Separately approved live cutover
+
+A live cutover is manual-only. Do not place it in an executable script, service,
+timer, or scheduled job. Deploying the reviewed code does not perform the
+cutover; deployment must leave Python authority enabled.
+
+Before cutover, require all of the following:
+
+1. The reviewed Python source is deployed and healthy with authority enabled.
+2. A rollback source and checksum are staged through the established deployment
+   process.
+3. The replacement remains verified observer/dry-run/no-broadcast.
+4. A fresh status read reports `enabled=true`.
+
+Only after separate operator approval, run the persistent change manually:
+
+```bash
+lightning-cli setconfig \
+  config=revenue-ops-fee-authority-enabled val=false transient=false
+```
+
+Inspect the direct `setconfig` response before proceeding. Its returned source
+must be exactly `config.setconfig`, and its effective value must be `false`.
+Stop and roll back if either check fails. Then read
+`revenue-fee-authority-status` and require `enabled=false`, `reason=setconfig`,
+and the expected generation advance. Re-read status after the next scheduled fee
+interval to prove the timer obeyed the disabled gate and did not perform a
+transition.
+
+This cutover disables Python fee mutation authority only. It does not authorize
+broadcasts by the replacement.
+
+## Persistent rollback
+
+If the cutover is aborted or verification fails, restore the durable default
+manually:
+
+```bash
+lightning-cli setconfig \
+  config=revenue-ops-fee-authority-enabled val=true transient=false
+```
+
+Inspect the direct response and require source `config.setconfig` with effective
+value `true`. Then require `revenue-fee-authority-status` to report
+`enabled=true`, `reason=setconfig`, and the expected generation advance. A
+temporary `transient=true` restore is not a substitute for persistent rollback
+after a persistent cutover.

--- a/modules/config.py
+++ b/modules/config.py
@@ -505,6 +505,8 @@ class Config:
     flow_interval: int = 3600      # 1 hour
     fee_interval: int = 1800       # 30 minutes (matches option default)
     rebalance_interval: int = 900  # 15 minutes
+    # Python remains the fee authority unless an explicit handoff disables it.
+    fee_authority_enabled: bool = True
     # Internal fee-cycle replay instrumentation. Disabled by default and
     # observational only; enabling affects the next naturally scheduled cycle.
     fee_replay_capture_enabled: bool = False
@@ -1311,6 +1313,9 @@ class ConfigSnapshot:
 
     # M-27: xpay/askrene parameters (were missing from snapshot)
     askrene_layer: str = 'xpay'
+
+    # Python fee-authority handoff state. Default-on preserves current behavior.
+    fee_authority_enabled: bool = True
 
     # Internal, default-off fee-cycle replay instrumentation.
     fee_replay_capture_enabled: bool = False

--- a/modules/fee_authority.py
+++ b/modules/fee_authority.py
@@ -1,0 +1,64 @@
+"""Thread-safe Python fee-authority state.
+
+This standalone model is intentionally independent of plugin wiring and CLN
+RPCs. Consumers receive immutable snapshots so a transition cannot be observed
+partially.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class FeeAuthorityStatus:
+    enabled: bool
+    generation: int
+    transitioned_at: int
+    reason: str
+
+
+class FeeAuthorityGate:
+    def __init__(
+        self,
+        enabled: bool = True,
+        now_fn: Callable[[], float] = time.time,
+    ):
+        self._now_fn = now_fn
+        self._lock = threading.Lock()
+        self._status = FeeAuthorityStatus(
+            enabled=enabled,
+            generation=0,
+            transitioned_at=int(self._now_fn()),
+            reason="initial",
+        )
+
+    def snapshot(self) -> FeeAuthorityStatus:
+        with self._lock:
+            return self._status
+
+    def set_enabled(self, enabled: bool, reason: str) -> FeeAuthorityStatus:
+        with self._lock:
+            if enabled == self._status.enabled:
+                return self._status
+            self._status = FeeAuthorityStatus(
+                enabled=enabled,
+                generation=self._status.generation + 1,
+                transitioned_at=int(self._now_fn()),
+                reason=reason,
+            )
+            return self._status
+
+    def deny_reason(self, operation: str) -> dict[str, object] | None:
+        status = self.snapshot()
+        if status.enabled:
+            return None
+        return {
+            "status": "blocked",
+            "reason": "fee_authority_disabled",
+            "operation": operation,
+            "generation": status.generation,
+            "transitioned_at": status.transitioned_at,
+        }

--- a/modules/fee_authority.py
+++ b/modules/fee_authority.py
@@ -1,15 +1,16 @@
-"""Thread-safe Python fee-authority state.
+"""Thread-safe Python fee-authority state and execution ownership.
 
-This standalone model is intentionally independent of plugin wiring and CLN
-RPCs. Consumers receive immutable snapshots so a transition cannot be observed
-partially.
+The gate publishes immutable status snapshots and owns a reentrant execution
+lease.  Disabling authority first closes admission, drains accepted work, and
+only then publishes the disabled generation.
 """
 from __future__ import annotations
 
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Iterator
 
 
 @dataclass(frozen=True)
@@ -20,41 +21,151 @@ class FeeAuthorityStatus:
     reason: str
 
 
+class FeeAuthorityTransitionError(RuntimeError):
+    """Raised when an authority transition cannot complete safely."""
+
+
 class FeeAuthorityGate:
     def __init__(
         self,
         enabled: bool = True,
         now_fn: Callable[[], float] = time.time,
+        *,
+        drain_timeout_seconds: float = 30.0,
+        monotonic_fn: Callable[[], float] = time.monotonic,
     ):
         self._now_fn = now_fn
-        self._lock = threading.Lock()
+        self._monotonic_fn = monotonic_fn
+        self._drain_timeout_seconds = float(drain_timeout_seconds)
+        if self._drain_timeout_seconds < 0:
+            raise ValueError("drain_timeout_seconds must be non-negative")
+
+        self._condition = threading.Condition(threading.RLock())
+        self._transition_lock = threading.Lock()
+        self._lease_local = threading.local()
+        self._active_outer_leases = 0
+        self._accepting = bool(enabled)
         self._status = FeeAuthorityStatus(
-            enabled=enabled,
+            enabled=bool(enabled),
             generation=0,
             transitioned_at=int(self._now_fn()),
             reason="initial",
         )
 
     def snapshot(self) -> FeeAuthorityStatus:
-        with self._lock:
+        with self._condition:
             return self._status
 
-    def set_enabled(self, enabled: bool, reason: str) -> FeeAuthorityStatus:
-        with self._lock:
-            if enabled == self._status.enabled:
-                return self._status
-            self._status = FeeAuthorityStatus(
-                enabled=enabled,
-                generation=self._status.generation + 1,
-                transitioned_at=int(self._now_fn()),
-                reason=reason,
+    def set_enabled(
+        self,
+        enabled: bool,
+        reason: str,
+        *,
+        timeout_seconds: float | None = None,
+    ) -> FeeAuthorityStatus:
+        enabled = bool(enabled)
+        timeout = (
+            self._drain_timeout_seconds
+            if timeout_seconds is None
+            else float(timeout_seconds)
+        )
+        if timeout < 0:
+            raise ValueError("timeout_seconds must be non-negative")
+
+        if not enabled and getattr(self._lease_local, "depth", 0) > 0:
+            raise FeeAuthorityTransitionError(
+                "cannot disable fee authority from inside an active execution lease"
             )
-            return self._status
+
+        with self._transition_lock:
+            with self._condition:
+                if enabled == self._status.enabled:
+                    return self._status
+
+                if enabled:
+                    self._status = self._transition_status(True, reason)
+                    self._accepting = True
+                    self._condition.notify_all()
+                    return self._status
+
+                # Close admission before waiting. Existing lease owners may
+                # continue through nested controller boundaries on this thread.
+                self._accepting = False
+                deadline = self._monotonic_fn() + timeout
+                while self._active_outer_leases:
+                    remaining = deadline - self._monotonic_fn()
+                    if remaining <= 0:
+                        self._accepting = True
+                        self._condition.notify_all()
+                        raise FeeAuthorityTransitionError(
+                            "timed out draining active fee-authority execution leases"
+                        )
+                    self._condition.wait(timeout=remaining)
+
+                self._status = self._transition_status(False, reason)
+                return self._status
+
+    @contextmanager
+    def execution_lease(
+        self,
+        operation: str,
+    ) -> Iterator[dict[str, object] | None]:
+        acquired = False
+        denial: dict[str, object] | None = None
+
+        with self._condition:
+            depth = getattr(self._lease_local, "depth", 0)
+            if depth > 0:
+                self._lease_local.depth = depth + 1
+                acquired = True
+            elif self._accepting and self._status.enabled:
+                self._active_outer_leases += 1
+                self._lease_local.depth = 1
+                acquired = True
+            else:
+                denial = self._blocked_reason(operation, self._status)
+
+        try:
+            yield denial
+        finally:
+            if acquired:
+                with self._condition:
+                    depth = getattr(self._lease_local, "depth", 0)
+                    if depth > 1:
+                        self._lease_local.depth = depth - 1
+                    elif depth == 1:
+                        del self._lease_local.depth
+                        self._active_outer_leases -= 1
+                        self._condition.notify_all()
+                    else:
+                        raise RuntimeError("fee-authority execution lease underflow")
 
     def deny_reason(self, operation: str) -> dict[str, object] | None:
-        status = self.snapshot()
-        if status.enabled:
-            return None
+        with self._condition:
+            if self._accepting and self._status.enabled:
+                return None
+            return self._blocked_reason(operation, self._status)
+
+    def _transition_status(
+        self,
+        enabled: bool,
+        reason: str,
+    ) -> FeeAuthorityStatus:
+        return FeeAuthorityStatus(
+            enabled=enabled,
+            generation=self._status.generation + 1,
+            transitioned_at=max(
+                self._status.transitioned_at,
+                int(self._now_fn()),
+            ),
+            reason=reason,
+        )
+
+    @staticmethod
+    def _blocked_reason(
+        operation: str,
+        status: FeeAuthorityStatus,
+    ) -> dict[str, object]:
         return {
             "status": "blocked",
             "reason": "fee_authority_disabled",

--- a/modules/fee_controller.py
+++ b/modules/fee_controller.py
@@ -7846,6 +7846,8 @@ class FeeController:
         Registered with PolicyManager at init; fires on revenue-policy
         set and delete (delete notifies with the default policy).
         """
+        if self.fee_authority_gate.deny_reason("policy_change_trigger") is not None:
+            return
         try:
             states = self.database.get_all_channel_states()
         except Exception as e:
@@ -9120,6 +9122,8 @@ class FeeController:
         Base weight: 10% of a settled forward.
         Amount boost: up to 3x for large forwards (>1M sats).
         """
+        if self.fee_authority_gate.deny_reason("failed_forward_trigger") is not None:
+            return
         if not channel_id or current_fee_ppm <= 0:
             return
         if not self.is_fee_relevant_failure(failcode, failreason):

--- a/modules/fee_controller.py
+++ b/modules/fee_controller.py
@@ -2951,7 +2951,8 @@ class FeeController:
                  policy_manager: Optional[PolicyManager] = None,
                  profitability_analyzer: Optional["ChannelProfitabilityAnalyzer"] = None,
                  temporary_fee_overlay_active: Optional[Callable[[str], bool]] = None,
-                 fee_authority_gate: Optional[FeeAuthorityGate] = None):
+                 *,
+                 fee_authority_gate: FeeAuthorityGate):
         """
         Initialize the fee controller.
 
@@ -2961,6 +2962,7 @@ class FeeController:
             database: Database instance
             policy_manager: Optional PolicyManager for peer-level fee policies
             profitability_analyzer: Optional profitability analyzer for ROI-based adjustments
+            fee_authority_gate: Shared, explicit Python fee-authority gate
         """
         self.plugin = plugin
         self.config = config
@@ -2968,7 +2970,18 @@ class FeeController:
         self.policy_manager = policy_manager
         self.profitability = profitability_analyzer
         self.temporary_fee_overlay_active = temporary_fee_overlay_active
-        self.fee_authority_gate = fee_authority_gate or FeeAuthorityGate()
+        if not isinstance(fee_authority_gate, FeeAuthorityGate):
+            raise TypeError("fee_authority_gate must be an explicit FeeAuthorityGate")
+        configured_authority = getattr(config, "fee_authority_enabled", None)
+        gate_authority = fee_authority_gate.snapshot().enabled
+        if (
+            isinstance(configured_authority, bool)
+            and configured_authority != gate_authority
+        ):
+            raise ValueError(
+                "fee authority configuration and shared gate must initially match"
+            )
+        self.fee_authority_gate = fee_authority_gate
         self.data_service = None  # Unified data service (injected by main plugin)
         if self.policy_manager and hasattr(self.policy_manager, "register_on_change"):
             try:
@@ -4536,6 +4549,14 @@ class FeeController:
         return pruned
 
     def wake_all_sleeping_channels(self) -> int:
+        with self.fee_authority_gate.execution_lease(
+            "wake_all_sleeping_channels"
+        ) as denial:
+            if denial is not None:
+                return 0
+            return self._wake_all_sleeping_channels_authorized()
+
+    def _wake_all_sleeping_channels_authorized(self) -> int:
         """
         Wake all channels immediately — clears both sleep mode AND observation windows.
 
@@ -4654,6 +4675,14 @@ class FeeController:
         return False
 
     def adjust_all_fees(self) -> List[FeeAdjustment]:
+        with self.fee_authority_gate.execution_lease(
+            "adjust_all_fees"
+        ) as denial:
+            if denial is not None:
+                return []
+            return self._adjust_all_fees_authorized()
+
+    def _adjust_all_fees_authorized(self) -> List[FeeAdjustment]:
         """Open one observational capture around the existing authority path."""
         try:
             cfg = self.config.snapshot() if hasattr(self.config, "snapshot") else self.config
@@ -7840,14 +7869,22 @@ class FeeController:
         return None
 
     def _handle_policy_change(self, peer_id: str, policy: PeerPolicy) -> None:
+        with self.fee_authority_gate.execution_lease(
+            "policy_change_trigger"
+        ) as denial:
+            if denial is not None:
+                return
+            self._handle_policy_change_authorized(peer_id, policy)
+
+    def _handle_policy_change_authorized(
+        self, peer_id: str, policy: PeerPolicy
+    ) -> None:
         """Wake the peer's sleeping channels so the next fee cycle applies
         the new policy.
 
         Registered with PolicyManager at init; fires on revenue-policy
         set and delete (delete notifies with the default policy).
         """
-        if self.fee_authority_gate.deny_reason("policy_change_trigger") is not None:
-            return
         try:
             states = self.database.get_all_channel_states()
         except Exception as e:
@@ -8142,15 +8179,45 @@ class FeeController:
                        htlcmax_msat: Optional[int] = None,
                        base_fee_msat_override: Optional[int] = None,
                        effective_min_fee_ppm: Optional[int] = None) -> Dict[str, Any]:
-        denial = self.fee_authority_gate.deny_reason("set_channel_fee")
-        if denial is not None:
-            return {
-                "success": False,
-                "channel_id": channel_id,
-                "fee_ppm": fee_ppm,
-                "message": "Fee authority disabled",
-                **denial,
-            }
+        with self.fee_authority_gate.execution_lease(
+            "set_channel_fee"
+        ) as denial:
+            if denial is not None:
+                return {
+                    "success": False,
+                    "channel_id": channel_id,
+                    "fee_ppm": fee_ppm,
+                    "message": "Fee authority disabled",
+                    **denial,
+                }
+            return self._set_channel_fee_authorized(
+                channel_id=channel_id,
+                fee_ppm=fee_ppm,
+                reason=reason,
+                manual=manual,
+                reason_code=reason_code,
+                enforce_limits=enforce_limits,
+                channel_info=channel_info,
+                htlcmin_msat=htlcmin_msat,
+                htlcmax_msat=htlcmax_msat,
+                base_fee_msat_override=base_fee_msat_override,
+                effective_min_fee_ppm=effective_min_fee_ppm,
+            )
+
+    def _set_channel_fee_authorized(
+        self,
+        channel_id: str,
+        fee_ppm: int,
+        reason: str = "manual",
+        manual: bool = False,
+        reason_code: Optional[str] = None,
+        enforce_limits: bool = True,
+        channel_info: Optional[Dict[str, Any]] = None,
+        htlcmin_msat: Optional[int] = None,
+        htlcmax_msat: Optional[int] = None,
+        base_fee_msat_override: Optional[int] = None,
+        effective_min_fee_ppm: Optional[int] = None,
+    ) -> Dict[str, Any]:
         request = {
             "channel_id": channel_id,
             "fee_ppm": fee_ppm,
@@ -8515,6 +8582,16 @@ class FeeController:
         return None
 
     def set_initial_fee(self, channel_id: str, peer_id: str) -> Optional[Dict[str, Any]]:
+        with self.fee_authority_gate.execution_lease(
+            "set_initial_fee"
+        ) as denial:
+            if denial is not None:
+                return None
+            return self._set_initial_fee_authorized(channel_id, peer_id)
+
+    def _set_initial_fee_authorized(
+        self, channel_id: str, peer_id: str
+    ) -> Optional[Dict[str, Any]]:
         """
         Set an initial fee for a newly opened channel.
 
@@ -9103,6 +9180,25 @@ class FeeController:
                               amount_msat: int = 0,
                               failcode: Optional[int] = None,
                               failreason: Optional[str] = None) -> None:
+        with self.fee_authority_gate.execution_lease(
+            "failed_forward_trigger"
+        ) as denial:
+            if denial is not None:
+                return
+            self._record_failed_forward_authorized(
+                channel_id,
+                current_fee_ppm,
+                amount_msat=amount_msat,
+                failcode=failcode,
+                failreason=failreason,
+            )
+
+    def _record_failed_forward_authorized(
+        self, channel_id: str, current_fee_ppm: int,
+        amount_msat: int = 0,
+        failcode: Optional[int] = None,
+        failreason: Optional[str] = None,
+    ) -> None:
         """Record a fee-relevant failed forward as a weak negative signal.
 
         Audit DTS-4 — two corrections to the original design:
@@ -9122,8 +9218,6 @@ class FeeController:
         Base weight: 10% of a settled forward.
         Amount boost: up to 3x for large forwards (>1M sats).
         """
-        if self.fee_authority_gate.deny_reason("failed_forward_trigger") is not None:
-            return
         if not channel_id or current_fee_ppm <= 0:
             return
         if not self.is_fee_relevant_failure(failcode, failreason):

--- a/modules/fee_controller.py
+++ b/modules/fee_controller.py
@@ -67,6 +67,7 @@ from pyln.client import Plugin, RpcError
 from .config import Config, ChainCostDefaults, LiquidityBuckets
 from . import admission_policy as _admission_policy
 from .database import Database
+from .fee_authority import FeeAuthorityGate
 from .fee_cycle_capture import (
     FeeCycleCaptureManager,
     bind_capture,
@@ -2949,7 +2950,8 @@ class FeeController:
     def __init__(self, plugin: Plugin, config: Config, database: Database,
                  policy_manager: Optional[PolicyManager] = None,
                  profitability_analyzer: Optional["ChannelProfitabilityAnalyzer"] = None,
-                 temporary_fee_overlay_active: Optional[Callable[[str], bool]] = None):
+                 temporary_fee_overlay_active: Optional[Callable[[str], bool]] = None,
+                 fee_authority_gate: Optional[FeeAuthorityGate] = None):
         """
         Initialize the fee controller.
 
@@ -2966,6 +2968,7 @@ class FeeController:
         self.policy_manager = policy_manager
         self.profitability = profitability_analyzer
         self.temporary_fee_overlay_active = temporary_fee_overlay_active
+        self.fee_authority_gate = fee_authority_gate or FeeAuthorityGate()
         self.data_service = None  # Unified data service (injected by main plugin)
         if self.policy_manager and hasattr(self.policy_manager, "register_on_change"):
             try:
@@ -8137,6 +8140,15 @@ class FeeController:
                        htlcmax_msat: Optional[int] = None,
                        base_fee_msat_override: Optional[int] = None,
                        effective_min_fee_ppm: Optional[int] = None) -> Dict[str, Any]:
+        denial = self.fee_authority_gate.deny_reason("set_channel_fee")
+        if denial is not None:
+            return {
+                "success": False,
+                "channel_id": channel_id,
+                "fee_ppm": fee_ppm,
+                "message": "Fee authority disabled",
+                **denial,
+            }
         request = {
             "channel_id": channel_id,
             "fee_ppm": fee_ppm,

--- a/modules/risk_profiles.py
+++ b/modules/risk_profiles.py
@@ -67,6 +67,7 @@ FIELD_CLASSIFICATION: Dict[str, str] = {
     "paused": "authority_control",
     "dry_run": "authority_control",
     "authority_level": "authority_control",
+    "fee_authority_enabled": "authority_control",
     "risk_profile": "authority_control",
     "econ_shadow_enabled": "authority_control",
     "econ_governor_rebalance_enabled": "authority_control",

--- a/tests/golden/test_golden_fee_damping.py
+++ b/tests/golden/test_golden_fee_damping.py
@@ -18,9 +18,11 @@ PROFILE = SimpleNamespace(
 )
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 @pytest.fixture
 def fc():
-    controller = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock())
+    controller = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock(), fee_authority_gate=FeeAuthorityGate())
     # Pin the fee profile so damping math is exercised with fixed inputs.
     controller._resolve_fee_profile = lambda cfg=None: ("golden", PROFILE)
     return controller

--- a/tests/golden/test_golden_htlcmax.py
+++ b/tests/golden/test_golden_htlcmax.py
@@ -10,9 +10,11 @@ from modules.fee_controller import FeeController
 from tests.golden.util import golden_check
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 @pytest.fixture
 def fc():
-    return FeeController(MagicMock(), MagicMock(spec=Config), MagicMock())
+    return FeeController(MagicMock(), MagicMock(spec=Config), MagicMock(), fee_authority_gate=FeeAuthorityGate())
 
 
 def _cfg(**over):

--- a/tests/test_admission_policy.py
+++ b/tests/test_admission_policy.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 from modules import admission_policy
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _cfg(**over):
     base = dict(
         enable_dynamic_htlcmax=True,
@@ -38,7 +40,7 @@ def test_direct_matches_shim():
     from unittest.mock import MagicMock
     from modules.config import Config
     from modules.fee_controller import FeeController
-    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock())
+    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock(), fee_authority_gate=FeeAuthorityGate())
     chan = {"capacity": 2_000_000, "spendable_msat": 1_900_000_000}
     for state in ("source", "sink", "balanced"):
         assert fc._compute_dynamic_htlcmax_msat(_cfg(), chan, state) == \
@@ -51,7 +53,7 @@ def test_constants_alias_intact():
     from unittest.mock import MagicMock
     from modules.config import Config
     from modules.fee_controller import FeeController
-    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock())
+    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock(), fee_authority_gate=FeeAuthorityGate())
     assert fc.HTLCMAX_FLOOR_MSAT == admission_policy.FLOOR_MSAT
     assert fc.HTLCMAX_DEPLETION_SPENDABLE_FRACTION == \
         admission_policy.DEPLETION_SPENDABLE_FRACTION

--- a/tests/test_competition_aware_mode.py
+++ b/tests/test_competition_aware_mode.py
@@ -14,6 +14,8 @@ from modules.fee_controller import FeeController
 from modules.config import STRING_ENUM_VALID_VALUES
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 @pytest.fixture
 def mock_plugin():
     p = MagicMock()
@@ -88,7 +90,7 @@ class TestNeighborFeePercentile:
         ]
 
     def _setup_fc(self, mock_plugin, mock_config, mock_database, channels: list):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc._our_node_id = "02ourid"
         fc.data_service = MagicMock()
         fc.data_service.get_channels = MagicMock(return_value={"channels": channels})

--- a/tests/test_drain_fee_pressure.py
+++ b/tests/test_drain_fee_pressure.py
@@ -18,6 +18,7 @@ sys.modules['pyln.client'] = mock_pyln
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from modules.fee_controller import FeeController as Controller
+from modules.fee_authority import FeeAuthorityGate
 from modules.config import Config
 
 
@@ -150,7 +151,7 @@ def _setup_db(mock_database, now):
 def _make_drain_fc(mock_plugin, mock_database, *, discount_max):
     """FeeController with ONE channel at ~97% local and zero forwards."""
     config = MagicMock(spec=Config)
-    fc = Controller(mock_plugin, config, mock_database)
+    fc = Controller(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
     cfg = _make_config_snapshot(drain_fee_discount_max=discount_max)
     fc.config.snapshot.return_value = cfg
     fc.config.dry_run = True  # set_channel_fee succeeds without RPC

--- a/tests/test_dts_pid.py
+++ b/tests/test_dts_pid.py
@@ -20,6 +20,8 @@ from modules.fee_controller import (
 )
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 class TestPIDState:
     """Unit tests for PIDState balance controller."""
 
@@ -1005,7 +1007,7 @@ def _make_config_snapshot(**overrides):
 def _make_fc_for_dts_pid(mock_plugin, mock_database):
     from modules.config import Config
     config = MagicMock(spec=Config)
-    fc = FeeController(mock_plugin, config, mock_database)
+    fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
     cfg = _make_config_snapshot()
     fc.config.snapshot.return_value = cfg
 

--- a/tests/test_econ_audit_wave.py
+++ b/tests/test_econ_audit_wave.py
@@ -38,6 +38,8 @@ from modules.fee_controller import (
 )
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 @pytest.fixture
 def mock_plugin():
     p = MagicMock()
@@ -55,7 +57,7 @@ def _make_fc(mock_plugin, mock_database):
     config = MagicMock()
     config.min_fee_ppm = 10
     config.max_fee_ppm = 5000
-    return FeeController(mock_plugin, config, mock_database)
+    return FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
 
 def _make_cfg_snapshot(**overrides):

--- a/tests/test_fee_authority_handoff.py
+++ b/tests/test_fee_authority_handoff.py
@@ -1,11 +1,13 @@
 import dataclasses
 import threading
+import time
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 from modules.config import Config
-from modules.fee_authority import FeeAuthorityGate
+from modules.fee_authority import FeeAuthorityGate, FeeAuthorityTransitionError
 from modules.fee_controller import ChannelCycleState, ChannelFeeState, FeeController
 from modules.policy_manager import PeerPolicy
 from tests.plugin_test_utils import load_plugin_module
@@ -75,6 +77,466 @@ def test_generation_and_timestamps_advance_only_on_transitions():
         enabled.transitioned_at,
     ] == [3000, 3010, 3020]
     assert [disabled.reason, enabled.reason] == ["cutover", "rollback"]
+
+
+def _wait_until(predicate, timeout: float = 1.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        threading.Event().wait(0.001)
+    return predicate()
+
+
+def test_transition_timestamps_do_not_decrease_when_wall_clock_moves_backward():
+    clock = iter([3000, 2990, 2980]).__next__
+    gate = FeeAuthorityGate(enabled=True, now_fn=clock)
+
+    disabled = gate.set_enabled(False, reason="cutover")
+    enabled = gate.set_enabled(True, reason="rollback")
+
+    assert disabled.transitioned_at == 3000
+    assert enabled.transitioned_at == 3000
+
+
+def test_disable_drains_outer_lease_and_denies_new_work_before_false_readback():
+    gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 5000)
+    mutation_entered = threading.Event()
+    finish_mutation = threading.Event()
+    nested_checked = threading.Event()
+    disable_finished = threading.Event()
+    statuses = []
+
+    def mutate():
+        with gate.execution_lease("manual_fee_mutation") as denial:
+            assert denial is None
+            mutation_entered.set()
+            assert _wait_until(
+                lambda: gate.deny_reason("new_fee_mutation") is not None
+            )
+            with gate.execution_lease("nested_set_channel_fee") as nested_denial:
+                assert nested_denial is None
+                nested_checked.set()
+            assert finish_mutation.wait(timeout=1)
+
+    def disable():
+        statuses.append(
+            gate.set_enabled(False, reason="setconfig", timeout_seconds=1)
+        )
+        disable_finished.set()
+
+    mutation = threading.Thread(target=mutate)
+    mutation.start()
+    assert mutation_entered.wait(timeout=1)
+
+    transition = threading.Thread(target=disable)
+    transition.start()
+    assert _wait_until(lambda: gate.deny_reason("new_fee_mutation") is not None)
+
+    assert gate.snapshot().enabled is True
+    assert not disable_finished.wait(timeout=0.05)
+    with gate.execution_lease("new_fee_mutation") as denial:
+        assert denial == {
+            "status": "blocked",
+            "reason": "fee_authority_disabled",
+            "operation": "new_fee_mutation",
+            "generation": 0,
+            "transitioned_at": 5000,
+        }
+    assert nested_checked.wait(timeout=1)
+
+    finish_mutation.set()
+    mutation.join(timeout=1)
+    transition.join(timeout=1)
+
+    assert not mutation.is_alive()
+    assert not transition.is_alive()
+    assert statuses[0].enabled is False
+    assert gate.snapshot() == statuses[0]
+
+
+def test_disable_timeout_restores_accepting_state_without_false_readback():
+    gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 6000)
+    mutation_entered = threading.Event()
+    finish_mutation = threading.Event()
+
+    def mutate():
+        with gate.execution_lease("scheduled_fee_cycle") as denial:
+            assert denial is None
+            mutation_entered.set()
+            assert finish_mutation.wait(timeout=1)
+
+    mutation = threading.Thread(target=mutate)
+    mutation.start()
+    assert mutation_entered.wait(timeout=1)
+
+    with pytest.raises(FeeAuthorityTransitionError, match="timed out"):
+        gate.set_enabled(False, reason="setconfig", timeout_seconds=0.01)
+
+    assert gate.snapshot().enabled is True
+    assert gate.deny_reason("new_fee_mutation") is None
+    with gate.execution_lease("new_fee_mutation") as denial:
+        assert denial is None
+
+    finish_mutation.set()
+    mutation.join(timeout=1)
+    assert not mutation.is_alive()
+
+
+def test_disable_from_inside_execution_lease_fails_without_changing_state():
+    gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 7000)
+
+    with gate.execution_lease("manual_fee_mutation") as denial:
+        assert denial is None
+        with pytest.raises(FeeAuthorityTransitionError, match="active execution lease"):
+            gate.set_enabled(False, reason="setconfig", timeout_seconds=0.01)
+
+    assert gate.snapshot().enabled is True
+    assert gate.deny_reason("new_fee_mutation") is None
+
+
+def test_controller_requires_explicit_shared_authority_gate():
+    with pytest.raises(TypeError, match="fee_authority_gate"):
+        FeeController(MagicMock(), Config(), MagicMock())
+
+
+def test_controller_rejects_config_and_gate_initial_authority_mismatch():
+    with pytest.raises(ValueError, match="fee authority"):
+        FeeController(
+            MagicMock(),
+            Config(fee_authority_enabled=False),
+            MagicMock(),
+            fee_authority_gate=FeeAuthorityGate(enabled=True),
+        )
+
+
+def test_direct_adjust_all_fees_is_denied_before_capture_or_cycle_state():
+    controller = FeeController(
+        MagicMock(),
+        Config(fee_authority_enabled=False),
+        MagicMock(),
+        fee_authority_gate=_disabled_gate(),
+    )
+    controller._fee_capture.begin_cycle = MagicMock()
+    controller._adjust_all_fees_bound = MagicMock(return_value=[])
+
+    result = controller.adjust_all_fees()
+
+    assert result == []
+    controller._fee_capture.begin_cycle.assert_not_called()
+    controller._adjust_all_fees_bound.assert_not_called()
+
+
+def test_direct_wake_all_is_denied_before_state_or_database_mutation():
+    channel_id = "123x456x0"
+    database = MagicMock()
+    controller = FeeController(
+        MagicMock(),
+        Config(fee_authority_enabled=False),
+        database,
+        fee_authority_gate=_disabled_gate(),
+    )
+    cycle = ChannelCycleState(
+        is_sleeping=True,
+        sleep_until=99_999,
+        stable_cycles=4,
+        last_update=99_999,
+    )
+    controller._cycle_states[channel_id] = cycle
+
+    result = controller.wake_all_sleeping_channels()
+
+    assert result == 0
+    assert (cycle.is_sleeping, cycle.sleep_until, cycle.stable_cycles) == (
+        True,
+        99_999,
+        4,
+    )
+    database.get_all_fee_strategy_states.assert_not_called()
+    database.update_fee_strategy_state.assert_not_called()
+
+
+def test_channel_open_initial_fee_is_denied_before_reads_or_prior_persistence():
+    database = MagicMock()
+    controller = FeeController(
+        MagicMock(),
+        Config(fee_authority_enabled=False),
+        database,
+        fee_authority_gate=_disabled_gate(),
+    )
+    controller.data_service = MagicMock()
+
+    result = controller.set_initial_fee(
+        "123x456x0",
+        "02" + "a" * 64,
+    )
+
+    assert result is None
+    controller.data_service.get_peer_channels.assert_not_called()
+    database.get_fee_strategy_state.assert_not_called()
+    database.update_fee_strategy_state.assert_not_called()
+
+
+def test_setconfig_disable_timeout_keeps_config_and_positive_readback_true():
+    mod = load_plugin_module()
+    mod.config = Config(fee_authority_enabled=True)
+    mod.fee_authority_gate = FeeAuthorityGate(
+        enabled=True,
+        now_fn=lambda: 8000,
+        drain_timeout_seconds=0.01,
+    )
+    lease_entered = threading.Event()
+    release_lease = threading.Event()
+
+    def hold_lease():
+        with mod.fee_authority_gate.execution_lease("scheduled_fee_cycle") as denial:
+            assert denial is None
+            lease_entered.set()
+            assert release_lease.wait(timeout=1)
+
+    worker = threading.Thread(target=hold_lease)
+    worker.start()
+    assert lease_entered.wait(timeout=1)
+
+    with pytest.raises(FeeAuthorityTransitionError, match="timed out"):
+        mod._on_fee_authority_change(
+            mod.plugin,
+            FEE_AUTHORITY_OPTION,
+            False,
+        )
+
+    assert mod.config.fee_authority_enabled is True
+    assert mod.revenue_fee_authority_status(mod.plugin)["enabled"] is True
+    assert mod.fee_authority_gate.deny_reason("new_fee_mutation") is None
+
+    release_lease.set()
+    worker.join(timeout=1)
+    assert not worker.is_alive()
+
+
+def test_inflight_manual_mutation_blocks_disabled_readback_and_new_mutation():
+    channel_id = "123x456x0"
+    peer_id = "02" + "b" * 64
+    gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 9000)
+    controller = FeeController(
+        MagicMock(),
+        Config(),
+        MagicMock(),
+        fee_authority_gate=gate,
+    )
+    controller.data_service = MagicMock()
+    rpc_entered = threading.Event()
+    release_rpc = threading.Event()
+    disable_finished = threading.Event()
+    mutation_results = []
+    disable_results = []
+
+    def set_channel(**_kwargs):
+        rpc_entered.set()
+        assert release_rpc.wait(timeout=1)
+        return {}
+
+    controller.data_service.set_channel.side_effect = set_channel
+
+    def mutate():
+        mutation_results.append(
+            controller.set_channel_fee(
+                channel_id,
+                125,
+                manual=True,
+                channel_info={
+                    "short_channel_id": channel_id,
+                    "peer_id": peer_id,
+                    "fee_proportional_millionths": 100,
+                },
+            )
+        )
+
+    def disable():
+        disable_results.append(
+            gate.set_enabled(False, reason="setconfig", timeout_seconds=1)
+        )
+        disable_finished.set()
+
+    mutation = threading.Thread(target=mutate)
+    mutation.start()
+    assert rpc_entered.wait(timeout=1)
+
+    transition = threading.Thread(target=disable)
+    transition.start()
+    assert _wait_until(lambda: gate.deny_reason("new_fee_mutation") is not None)
+
+    assert gate.snapshot().enabled is True
+    assert not disable_finished.wait(timeout=0.05)
+    blocked = controller.set_channel_fee(
+        channel_id,
+        130,
+        manual=True,
+        channel_info={
+            "short_channel_id": channel_id,
+            "peer_id": peer_id,
+            "fee_proportional_millionths": 100,
+        },
+    )
+    assert blocked["reason"] == "fee_authority_disabled"
+    assert controller.data_service.set_channel.call_count == 1
+
+    release_rpc.set()
+    mutation.join(timeout=1)
+    transition.join(timeout=1)
+
+    assert not mutation.is_alive()
+    assert not transition.is_alive()
+    assert mutation_results[0]["success"] is True
+    assert disable_results[0].enabled is False
+
+
+def test_inflight_scheduled_cycle_blocks_setconfig_readback_and_new_cycle():
+    mod = load_plugin_module()
+    mod.config = Config(fee_authority_enabled=True)
+    mod.fee_authority_gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 9500)
+    cycle_entered = threading.Event()
+    release_cycle = threading.Event()
+    disable_finished = threading.Event()
+    cycle_results = []
+    disable_results = []
+
+    def adjust_all_fees():
+        cycle_entered.set()
+        assert release_cycle.wait(timeout=1)
+        return []
+
+    mod.fee_controller = MagicMock()
+    mod.fee_controller.adjust_all_fees.side_effect = adjust_all_fees
+
+    def run_cycle():
+        cycle_results.append(mod.run_fee_adjustment())
+
+    def disable():
+        disable_results.append(
+            mod._on_fee_authority_change(
+                mod.plugin,
+                FEE_AUTHORITY_OPTION,
+                False,
+            )
+        )
+        disable_finished.set()
+
+    cycle = threading.Thread(target=run_cycle)
+    cycle.start()
+    assert cycle_entered.wait(timeout=1)
+
+    transition = threading.Thread(target=disable)
+    transition.start()
+    try:
+        assert _wait_until(
+            lambda: mod.fee_authority_gate.deny_reason("new_fee_cycle") is not None
+        )
+        assert mod.config.fee_authority_enabled is True
+        assert mod.revenue_fee_authority_status(mod.plugin)["enabled"] is True
+        assert not disable_finished.wait(timeout=0.05)
+
+        blocked = mod.run_fee_adjustment()
+        assert blocked["reason"] == "fee_authority_disabled"
+        assert mod.fee_controller.adjust_all_fees.call_count == 1
+    finally:
+        release_cycle.set()
+        cycle.join(timeout=1)
+        transition.join(timeout=1)
+
+    assert not cycle.is_alive()
+    assert not transition.is_alive()
+    assert cycle_results == [[]]
+    assert disable_results == [
+        f"{FEE_AUTHORITY_OPTION}=false generation=1"
+    ]
+    assert mod.config.fee_authority_enabled is False
+    assert mod.revenue_fee_authority_status(mod.plugin)["enabled"] is False
+
+
+def test_inflight_manual_rpc_blocks_disabled_readback_before_rate_limit_finishes():
+    mod = load_plugin_module()
+    mod.config = Config(
+        fee_authority_enabled=True,
+        min_fee_ppm=10,
+        max_fee_ppm=5000,
+    )
+    mod.fee_authority_gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 9750)
+    mod.fee_controller = MagicMock()
+    mod.fee_controller.set_channel_fee.return_value = {"success": True}
+    rate_limit_entered = threading.Event()
+    release_rate_limit = threading.Event()
+    disable_finished = threading.Event()
+    rpc_results = []
+
+    mod.force_rate_limiter = MagicMock()
+
+    def check_rate_limit(_operation):
+        rate_limit_entered.set()
+        assert release_rate_limit.wait(timeout=1)
+        return True, "ok"
+
+    mod.force_rate_limiter.check_rate_limit.side_effect = check_rate_limit
+
+    def set_fee():
+        rpc_results.append(
+            mod.revenue_set_fee(
+                mod.plugin,
+                channel_id="123x456x0",
+                fee_ppm=125,
+                force=True,
+            )
+        )
+
+    transition_results = []
+
+    def disable():
+        transition_results.append(
+            mod._on_fee_authority_change(
+                mod.plugin,
+                FEE_AUTHORITY_OPTION,
+                False,
+            )
+        )
+        disable_finished.set()
+
+    rpc = threading.Thread(target=set_fee)
+    rpc.start()
+    assert rate_limit_entered.wait(timeout=1)
+
+    transition = threading.Thread(target=disable)
+    transition.start()
+    try:
+        assert _wait_until(
+            lambda: mod.fee_authority_gate.deny_reason("new_manual_rpc") is not None
+        )
+        assert mod.revenue_fee_authority_status(mod.plugin)["enabled"] is True
+        assert not disable_finished.wait(timeout=0.05)
+
+        blocked = mod.revenue_set_fee(
+            mod.plugin,
+            channel_id="123x456x0",
+            fee_ppm=130,
+            force=True,
+        )
+        assert blocked["reason"] == "fee_authority_disabled"
+        assert mod.force_rate_limiter.check_rate_limit.call_count == 1
+    finally:
+        release_rate_limit.set()
+        rpc.join(timeout=1)
+        transition.join(timeout=1)
+
+    assert not rpc.is_alive()
+    assert not transition.is_alive()
+    assert rpc_results == [{
+        "status": "success",
+        "channel": "123x456x0",
+        "new_fee_ppm": 125,
+        "success": True,
+    }]
+    assert transition_results == [
+        f"{FEE_AUTHORITY_OPTION}=false generation=1"
+    ]
 
 
 def test_deny_reason_is_stable_and_machine_readable():
@@ -204,7 +666,7 @@ def test_authority_callback_rejects_invalid_input_without_mutation(invalid):
     assert mod.fee_authority_gate.snapshot() is before
 
 
-def test_authority_callback_updates_config_and_gate_under_config_lock():
+def test_authority_callback_does_not_return_before_config_matches_gate():
     mod = load_plugin_module()
     mod.config = Config(fee_authority_enabled=True)
     mod.fee_authority_gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 8000)
@@ -231,8 +693,11 @@ def test_authority_callback_updates_config_and_gate_under_config_lock():
         worker.start()
         assert callback_started.wait(timeout=1)
         assert not callback_finished.wait(timeout=0.05)
+        # The gate is the sole authority source and may safely publish the
+        # drained disabled state before the diagnostic Config field catches up.
+        # The callback itself must not return until both agree.
         assert mod.config.fee_authority_enabled is True
-        assert mod.fee_authority_gate.snapshot().enabled is True
+        assert mod.fee_authority_gate.snapshot().enabled is False
     finally:
         mod.config._lock.release()
 
@@ -383,7 +848,7 @@ def test_record_failed_forward_defense_leaves_fee_state_unchanged_when_disabled(
     database = MagicMock()
     controller = FeeController(
         MagicMock(),
-        Config(),
+        Config(fee_authority_enabled=False),
         database,
         fee_authority_gate=_disabled_gate(),
     )
@@ -412,7 +877,7 @@ def test_policy_change_defense_leaves_sleeping_fee_state_unchanged_when_disabled
     ]
     controller = FeeController(
         MagicMock(),
-        Config(),
+        Config(fee_authority_enabled=False),
         database,
         fee_authority_gate=_disabled_gate(),
     )
@@ -499,3 +964,56 @@ def test_disabled_authority_keeps_policy_reads_live():
         "count": 1,
     }
     mod.policy_manager.get_all_policies.assert_called_once_with()
+
+
+RUNBOOK_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "runbooks"
+    / "python-fee-authority-handoff.md"
+)
+
+
+def test_runbook_pins_nested_setconfig_value_and_source_contract():
+    runbook = RUNBOOK_PATH.read_text()
+
+    assert ".config.value_bool == false" in runbook
+    assert ".config.value_bool == true" in runbook
+    assert 'test("(^|/)config[.]setconfig:[1-9][0-9]*$")' in runbook
+    assert "/data/lightningd/bitcoin/config.setconfig:1" in runbook
+
+
+def test_runbook_orders_post_activation_rollback_before_python_reenable():
+    runbook = RUNBOOK_PATH.read_text()
+    section = runbook.split("### Post-activation rollback", 1)[1]
+
+    ordered_steps = [
+        "Disable Rust fee broadcasts",
+        "no Rust fee batch is active",
+        "Remove the cutover arm",
+        "Reconcile or quarantine every ambiguous Rust action",
+        "Re-enable Python fee authority",
+    ]
+    positions = [section.index(step) for step in ordered_steps]
+
+    assert positions == sorted(positions)
+    assert "pre-arm and pre-Rust-activation only" in runbook
+
+
+def test_runbook_requires_persistent_option_cleanup_before_old_source_revert():
+    runbook = RUNBOOK_PATH.read_text()
+    section = runbook.split(
+        "## Reverting to source that does not register the option",
+        1,
+    )[1]
+
+    ordered_steps = [
+        "re-enable Python fee authority persistently",
+        "resolved `config.setconfig` path",
+        "remove exactly the active",
+        "revert to source that does not register",
+    ]
+    positions = [section.index(step) for step in ordered_steps]
+
+    assert positions == sorted(positions)
+    assert "must not be automated" in section

--- a/tests/test_fee_authority_handoff.py
+++ b/tests/test_fee_authority_handoff.py
@@ -801,6 +801,194 @@ def test_wake_all_rpc_preserves_outer_shape_without_mutating_controller_state():
     mod.fee_controller.wake_all_sleeping_channels.assert_not_called()
 
 
+def test_fee_cycle_rpc_holds_outer_lease_across_delegation_during_drain():
+    mod = load_plugin_module()
+    mod.config = Config(fee_authority_enabled=True)
+    mod.fee_authority_gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 10_100)
+    mod.revenue_fee_debug = MagicMock(return_value={"summary": {"total": 1}})
+    delegation_entered = threading.Event()
+    nested_checked = threading.Event()
+    release_delegation = threading.Event()
+    disable_finished = threading.Event()
+    mutations = []
+    nested_denials = []
+    enabled_during_delegation = []
+    transition_finished_during_delegation = []
+    rpc_results = []
+    transition_results = []
+
+    def delegated_cycle():
+        delegation_entered.set()
+        assert _wait_until(
+            lambda: mod.fee_authority_gate.deny_reason("drain_probe") is not None
+        )
+        with mod.fee_authority_gate.execution_lease("fee_adjustment") as denial:
+            nested_denials.append(denial)
+            enabled_during_delegation.append(
+                mod.revenue_fee_authority_status(mod.plugin)["enabled"]
+            )
+            transition_finished_during_delegation.append(disable_finished.is_set())
+            nested_checked.set()
+            assert release_delegation.wait(timeout=1)
+            if denial is not None:
+                return denial
+            mutations.append("fee-cycle")
+            return [{"channel_id": "123x456x0"}]
+
+    mod.run_fee_adjustment = delegated_cycle
+
+    def run_rpc():
+        rpc_results.append(mod.revenue_fee_cycle(mod.plugin))
+
+    def disable():
+        transition_results.append(
+            mod._on_fee_authority_change(
+                mod.plugin,
+                FEE_AUTHORITY_OPTION,
+                False,
+            )
+        )
+        disable_finished.set()
+
+    rpc = threading.Thread(target=run_rpc)
+    rpc.start()
+    assert delegation_entered.wait(timeout=1)
+
+    transition = threading.Thread(target=disable)
+    transition.start()
+    assert nested_checked.wait(timeout=1)
+    try:
+        assert not disable_finished.wait(timeout=0.05)
+    finally:
+        release_delegation.set()
+        rpc.join(timeout=1)
+        transition.join(timeout=1)
+
+    assert not rpc.is_alive()
+    assert not transition.is_alive()
+    assert rpc_results == [{
+        "ok": True,
+        "adjusted_channels": 1,
+        "fee_debug": {"summary": {"total": 1}},
+    }]
+    assert mutations == ["fee-cycle"]
+    assert nested_denials == [None]
+    assert enabled_during_delegation == [True]
+    assert transition_finished_during_delegation == [False]
+    assert transition_results == [
+        f"{FEE_AUTHORITY_OPTION}=false generation=1"
+    ]
+
+    blocked = mod.revenue_fee_cycle(mod.plugin)
+    assert blocked == {
+        "ok": False,
+        "adjusted_channels": 0,
+        "fee_debug": {},
+        "status": "blocked",
+        "reason": "fee_authority_disabled",
+        "operation": "revenue-fee-cycle",
+        "generation": 1,
+        "transitioned_at": 10_100,
+    }
+    assert mutations == ["fee-cycle"]
+    mod.revenue_fee_debug.assert_called_once_with(mod.plugin)
+
+
+def test_wake_all_rpc_holds_outer_lease_across_delegation_during_drain():
+    mod = load_plugin_module()
+    mod.config = Config(fee_authority_enabled=True)
+    mod.fee_authority_gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 10_200)
+    mod.fee_controller = MagicMock()
+    delegation_entered = threading.Event()
+    nested_checked = threading.Event()
+    release_delegation = threading.Event()
+    disable_finished = threading.Event()
+    mutations = []
+    nested_denials = []
+    enabled_during_delegation = []
+    transition_finished_during_delegation = []
+    rpc_results = []
+    transition_results = []
+
+    def delegated_wake():
+        delegation_entered.set()
+        assert _wait_until(
+            lambda: mod.fee_authority_gate.deny_reason("drain_probe") is not None
+        )
+        with mod.fee_authority_gate.execution_lease("controller_wake") as denial:
+            nested_denials.append(denial)
+            enabled_during_delegation.append(
+                mod.revenue_fee_authority_status(mod.plugin)["enabled"]
+            )
+            transition_finished_during_delegation.append(disable_finished.is_set())
+            nested_checked.set()
+            assert release_delegation.wait(timeout=1)
+            if denial is not None:
+                return 0
+            mutations.append("wake-all")
+            return 1
+
+    mod.fee_controller.wake_all_sleeping_channels.side_effect = delegated_wake
+
+    def run_rpc():
+        rpc_results.append(mod.revenue_wake_all(mod.plugin))
+
+    def disable():
+        transition_results.append(
+            mod._on_fee_authority_change(
+                mod.plugin,
+                FEE_AUTHORITY_OPTION,
+                False,
+            )
+        )
+        disable_finished.set()
+
+    rpc = threading.Thread(target=run_rpc)
+    rpc.start()
+    assert delegation_entered.wait(timeout=1)
+
+    transition = threading.Thread(target=disable)
+    transition.start()
+    assert nested_checked.wait(timeout=1)
+    try:
+        assert not disable_finished.wait(timeout=0.05)
+    finally:
+        release_delegation.set()
+        rpc.join(timeout=1)
+        transition.join(timeout=1)
+
+    assert not rpc.is_alive()
+    assert not transition.is_alive()
+    assert rpc_results == [{
+        "status": "ok",
+        "channels_woken": 1,
+        "message": (
+            "Woke 1 sleeping channel(s). They will be evaluated on the next "
+            "fee cycle."
+        ),
+    }]
+    assert mutations == ["wake-all"]
+    assert nested_denials == [None]
+    assert enabled_during_delegation == [True]
+    assert transition_finished_during_delegation == [False]
+    assert transition_results == [
+        f"{FEE_AUTHORITY_OPTION}=false generation=1"
+    ]
+
+    blocked = mod.revenue_wake_all(mod.plugin)
+    assert blocked == {
+        "status": "blocked",
+        "channels_woken": 0,
+        "message": "Fee authority disabled",
+        "reason": "fee_authority_disabled",
+        "operation": "revenue-wake-all",
+        "generation": 1,
+        "transitioned_at": 10_200,
+    }
+    assert mutations == ["wake-all"]
+    mod.fee_controller.wake_all_sleeping_channels.assert_called_once_with()
+
+
 def test_set_fee_rpc_blocks_before_rate_limit_or_controller_work():
     mod = load_plugin_module()
     mod.fee_authority_gate = _disabled_gate()
@@ -1017,3 +1205,16 @@ def test_runbook_requires_persistent_option_cleanup_before_old_source_revert():
 
     assert positions == sorted(positions)
     assert "must not be automated" in section
+
+
+def test_runbook_contract_inventory_names_all_fee_authority_boundaries():
+    runbook = RUNBOOK_PATH.read_text()
+    contract = runbook.split("## Contract", 1)[1].split(
+        "## Inspect authority",
+        1,
+    )[0]
+
+    assert "channel-open initial-fee handling" in contract
+    assert "direct controller fee-evaluation" in contract
+    assert "direct controller wake" in contract
+    assert "dynamic `htlcmax`" in contract

--- a/tests/test_fee_authority_handoff.py
+++ b/tests/test_fee_authority_handoff.py
@@ -1,5 +1,6 @@
 import dataclasses
 import threading
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,6 +10,12 @@ from tests.plugin_test_utils import load_plugin_module
 
 
 FEE_AUTHORITY_OPTION = "revenue-ops-fee-authority-enabled"
+
+
+def _disabled_gate(now: int = 10_000) -> FeeAuthorityGate:
+    gate = FeeAuthorityGate(enabled=True, now_fn=lambda: now)
+    gate.set_enabled(False, reason="setconfig")
+    return gate
 
 
 def test_authority_config_defaults_on_and_is_snapshotted():
@@ -249,3 +256,121 @@ def test_fee_authority_status_rpc_returns_positive_in_process_state(monkeypatch)
         "observed_at": 9010,
         "reason": "initial",
     }
+
+
+def test_scheduled_fee_cycle_does_not_enter_run_fee_adjustment_when_disabled():
+    mod = load_plugin_module()
+    mod.fee_authority_gate = _disabled_gate()
+    mod.run_fee_adjustment = MagicMock(return_value=[])
+
+    result = mod._run_scheduled_fee_adjustment()
+
+    assert result == {
+        "status": "blocked",
+        "reason": "fee_authority_disabled",
+        "operation": "scheduled_fee_cycle",
+        "generation": 1,
+        "transitioned_at": 10_000,
+    }
+    mod.run_fee_adjustment.assert_not_called()
+
+
+def test_run_fee_adjustment_does_not_enter_controller_when_disabled():
+    mod = load_plugin_module()
+    mod.fee_authority_gate = _disabled_gate()
+    mod.fee_controller = MagicMock()
+    mod.fee_controller.adjust_all_fees.return_value = []
+
+    result = mod.run_fee_adjustment()
+
+    assert result == {
+        "status": "blocked",
+        "reason": "fee_authority_disabled",
+        "operation": "fee_adjustment",
+        "generation": 1,
+        "transitioned_at": 10_000,
+    }
+    mod.fee_controller.adjust_all_fees.assert_not_called()
+
+
+def test_fee_cycle_rpc_preserves_outer_shape_when_authority_is_disabled():
+    mod = load_plugin_module()
+    mod.fee_authority_gate = _disabled_gate()
+    mod.run_fee_adjustment = MagicMock(return_value=[])
+    mod.revenue_fee_debug = MagicMock(return_value={"summary": {"total": 1}})
+
+    result = mod.revenue_fee_cycle(mod.plugin)
+
+    assert result == {
+        "ok": False,
+        "adjusted_channels": 0,
+        "fee_debug": {},
+        "status": "blocked",
+        "reason": "fee_authority_disabled",
+        "operation": "revenue-fee-cycle",
+        "generation": 1,
+        "transitioned_at": 10_000,
+    }
+    mod.run_fee_adjustment.assert_not_called()
+    mod.revenue_fee_debug.assert_not_called()
+
+
+def test_wake_all_rpc_preserves_outer_shape_without_mutating_controller_state():
+    mod = load_plugin_module()
+    mod.fee_authority_gate = _disabled_gate()
+    mod.fee_controller = MagicMock()
+
+    result = mod.revenue_wake_all(mod.plugin)
+
+    assert result == {
+        "status": "blocked",
+        "channels_woken": 0,
+        "message": "Fee authority disabled",
+        "reason": "fee_authority_disabled",
+        "operation": "revenue-wake-all",
+        "generation": 1,
+        "transitioned_at": 10_000,
+    }
+    mod.fee_controller.wake_all_sleeping_channels.assert_not_called()
+
+
+def test_set_fee_rpc_blocks_before_rate_limit_or_controller_work():
+    mod = load_plugin_module()
+    mod.fee_authority_gate = _disabled_gate()
+    mod.config = Config(min_fee_ppm=10, max_fee_ppm=5000)
+    mod.fee_controller = MagicMock()
+    mod.force_rate_limiter = MagicMock()
+    mod.force_rate_limiter.check_rate_limit.return_value = (True, "ok")
+
+    result = mod.revenue_set_fee(
+        mod.plugin,
+        channel_id="123x456x0",
+        fee_ppm=125,
+        force=True,
+    )
+
+    assert result == {
+        "status": "blocked",
+        "error": "Fee authority disabled",
+        "reason": "fee_authority_disabled",
+        "operation": "revenue-set-fee",
+        "generation": 1,
+        "transitioned_at": 10_000,
+    }
+    mod.force_rate_limiter.check_rate_limit.assert_not_called()
+    mod.fee_controller.set_channel_fee.assert_not_called()
+
+
+def test_reenabling_authority_restores_existing_fee_adjustment_path():
+    mod = load_plugin_module()
+    mod.fee_authority_gate = _disabled_gate()
+    mod.fee_controller = MagicMock()
+    mod.fee_controller.adjust_all_fees.return_value = []
+
+    blocked = mod.run_fee_adjustment()
+    mod.fee_authority_gate.set_enabled(True, reason="rollback")
+    enabled = mod.run_fee_adjustment()
+
+    assert blocked["reason"] == "fee_authority_disabled"
+    assert enabled == []
+    mod.fee_controller.adjust_all_fees.assert_called_once_with()

--- a/tests/test_fee_authority_handoff.py
+++ b/tests/test_fee_authority_handoff.py
@@ -6,6 +6,8 @@ import pytest
 
 from modules.config import Config
 from modules.fee_authority import FeeAuthorityGate
+from modules.fee_controller import ChannelCycleState, ChannelFeeState, FeeController
+from modules.policy_manager import PeerPolicy
 from tests.plugin_test_utils import load_plugin_module
 
 
@@ -374,3 +376,126 @@ def test_reenabling_authority_restores_existing_fee_adjustment_path():
     assert blocked["reason"] == "fee_authority_disabled"
     assert enabled == []
     mod.fee_controller.adjust_all_fees.assert_called_once_with()
+
+
+def test_record_failed_forward_defense_leaves_fee_state_unchanged_when_disabled():
+    channel_id = "123x456x0"
+    database = MagicMock()
+    controller = FeeController(
+        MagicMock(),
+        Config(),
+        database,
+        fee_authority_gate=_disabled_gate(),
+    )
+    fee_state = ChannelFeeState(last_fee_ppm=500)
+    controller._channel_fee_states[channel_id] = fee_state
+
+    controller.record_failed_forward(
+        channel_id,
+        current_fee_ppm=500,
+        amount_msat=5_000_000_000,
+        failcode=0x1000 | 12,
+        failreason="WIRE_FEE_INSUFFICIENT",
+    )
+
+    assert fee_state.thompson.posterior_bias == []
+    assert channel_id not in controller._last_failure_nudge_ts
+    database.get_fee_strategy_state.assert_not_called()
+
+
+def test_policy_change_defense_leaves_sleeping_fee_state_unchanged_when_disabled():
+    peer_id = "02" + "a" * 64
+    channel_id = "123x456x0"
+    database = MagicMock()
+    database.get_all_channel_states.return_value = [
+        {"peer_id": peer_id, "channel_id": channel_id},
+    ]
+    controller = FeeController(
+        MagicMock(),
+        Config(),
+        database,
+        fee_authority_gate=_disabled_gate(),
+    )
+    cycle = ChannelCycleState(
+        is_sleeping=True,
+        sleep_until=99_999,
+        stable_cycles=4,
+    )
+    fee_state = ChannelFeeState(
+        is_sleeping=True,
+        sleep_until=99_999,
+        stable_cycles=4,
+    )
+    controller._cycle_states[channel_id] = cycle
+    controller._channel_fee_states[channel_id] = fee_state
+
+    controller._handle_policy_change(peer_id, PeerPolicy(peer_id=peer_id))
+
+    assert (cycle.is_sleeping, cycle.sleep_until, cycle.stable_cycles) == (
+        True,
+        99_999,
+        4,
+    )
+    assert (
+        fee_state.is_sleeping,
+        fee_state.sleep_until,
+        fee_state.stable_cycles,
+    ) == (True, 99_999, 4)
+    database.get_all_channel_states.assert_not_called()
+    database.update_fee_strategy_state.assert_not_called()
+
+
+def test_disabled_authority_keeps_capture_control_and_status_reads_live(
+    monkeypatch,
+):
+    mod = load_plugin_module()
+    mod.fee_authority_gate = _disabled_gate()
+    mod.config = Config(
+        fee_authority_enabled=False,
+        fee_replay_capture_enabled=False,
+    )
+    mod.fee_controller = MagicMock()
+    mod.fee_controller._fee_capture.set_enabled.return_value = True
+    monkeypatch.setattr(mod.time, "time", lambda: 10_010)
+
+    result = mod._on_fee_replay_capture_change(
+        mod.plugin,
+        "revenue-ops-fee-replay-capture-enabled",
+        True,
+    )
+    status = mod.revenue_fee_authority_status(mod.plugin)
+
+    assert result is None
+    assert mod.config.fee_replay_capture_enabled is True
+    mod.fee_controller._fee_capture.set_enabled.assert_called_once_with(
+        True,
+        timeout_seconds=5.0,
+    )
+    assert status == {
+        "schema": "revenue_ops_fee_authority/v1",
+        "enabled": False,
+        "generation": 1,
+        "transitioned_at": 10_000,
+        "observed_at": 10_010,
+        "reason": "setconfig",
+    }
+
+
+def test_disabled_authority_keeps_policy_reads_live():
+    mod = load_plugin_module()
+    mod.fee_authority_gate = _disabled_gate()
+    policy = MagicMock()
+    policy.to_dict.return_value = {
+        "peer_id": "02" + "b" * 64,
+        "strategy": "dynamic",
+    }
+    mod.policy_manager = MagicMock()
+    mod.policy_manager.get_all_policies.return_value = [policy]
+
+    result = mod.revenue_policy(mod.plugin, action="list")
+
+    assert result == {
+        "policies": [policy.to_dict.return_value],
+        "count": 1,
+    }
+    mod.policy_manager.get_all_policies.assert_called_once_with()

--- a/tests/test_fee_authority_handoff.py
+++ b/tests/test_fee_authority_handoff.py
@@ -1,0 +1,118 @@
+import dataclasses
+import threading
+
+import pytest
+
+from modules.fee_authority import FeeAuthorityGate
+
+
+def test_gate_defaults_enabled_and_transitions_once():
+    clock = iter([1000, 1001, 1002]).__next__
+    gate = FeeAuthorityGate(enabled=True, now_fn=clock)
+    assert gate.snapshot().enabled is True
+    off = gate.set_enabled(False, reason="setconfig")
+    assert (off.enabled, off.generation, off.transitioned_at) == (
+        False,
+        1,
+        1001,
+    )
+    again = gate.set_enabled(False, reason="setconfig")
+    assert again == off
+
+
+def test_status_is_immutable_and_idempotent_write_keeps_reason():
+    clock = iter([2000, 2001]).__next__
+    gate = FeeAuthorityGate(enabled=True, now_fn=clock)
+
+    off = gate.set_enabled(False, reason="setconfig")
+    unchanged = gate.set_enabled(False, reason="different-reason")
+
+    assert unchanged is off
+    assert unchanged.reason == "setconfig"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        unchanged.reason = "changed"
+
+
+def test_generation_and_timestamps_advance_only_on_transitions():
+    clock = iter([3000, 3010, 3020]).__next__
+    gate = FeeAuthorityGate(enabled=True, now_fn=clock)
+
+    initial = gate.snapshot()
+    unchanged = gate.set_enabled(True, reason="no-op")
+    disabled = gate.set_enabled(False, reason="cutover")
+    enabled = gate.set_enabled(True, reason="rollback")
+
+    assert unchanged is initial
+    assert [initial.generation, disabled.generation, enabled.generation] == [
+        0,
+        1,
+        2,
+    ]
+    assert [
+        initial.transitioned_at,
+        disabled.transitioned_at,
+        enabled.transitioned_at,
+    ] == [3000, 3010, 3020]
+    assert [disabled.reason, enabled.reason] == ["cutover", "rollback"]
+
+
+def test_deny_reason_is_stable_and_machine_readable():
+    clock = iter([4000, 4001]).__next__
+    gate = FeeAuthorityGate(enabled=True, now_fn=clock)
+    assert gate.deny_reason("scheduled_fee_cycle") is None
+
+    gate.set_enabled(False, reason="setconfig")
+
+    assert gate.deny_reason("scheduled_fee_cycle") == {
+        "status": "blocked",
+        "reason": "fee_authority_disabled",
+        "operation": "scheduled_fee_cycle",
+        "generation": 1,
+        "transitioned_at": 4001,
+    }
+
+
+def test_concurrent_snapshot_waits_for_complete_transition():
+    transition_clock_entered = threading.Event()
+    finish_transition = threading.Event()
+    reader_started = threading.Event()
+    reader_finished = threading.Event()
+    statuses = []
+    clock_calls = 0
+
+    def clock():
+        nonlocal clock_calls
+        clock_calls += 1
+        if clock_calls == 1:
+            return 5000
+        transition_clock_entered.set()
+        finish_transition.wait(timeout=5)
+        return 5001
+
+    gate = FeeAuthorityGate(enabled=True, now_fn=clock)
+
+    def disable():
+        statuses.append(gate.set_enabled(False, reason="setconfig"))
+
+    def read_during_transition():
+        reader_started.set()
+        statuses.append(gate.snapshot())
+        reader_finished.set()
+
+    writer = threading.Thread(target=disable)
+    reader = threading.Thread(target=read_during_transition)
+    writer.start()
+    assert transition_clock_entered.wait(timeout=1)
+    reader.start()
+    assert reader_started.wait(timeout=1)
+    assert not reader_finished.wait(timeout=0.05)
+
+    finish_transition.set()
+    writer.join(timeout=1)
+    reader.join(timeout=1)
+
+    assert not writer.is_alive()
+    assert not reader.is_alive()
+    assert len(statuses) == 2
+    assert statuses[0] == statuses[1]
+    assert (statuses[0].enabled, statuses[0].generation) == (False, 1)

--- a/tests/test_fee_authority_handoff.py
+++ b/tests/test_fee_authority_handoff.py
@@ -3,7 +3,19 @@ import threading
 
 import pytest
 
+from modules.config import Config
 from modules.fee_authority import FeeAuthorityGate
+from tests.plugin_test_utils import load_plugin_module
+
+
+FEE_AUTHORITY_OPTION = "revenue-ops-fee-authority-enabled"
+
+
+def test_authority_config_defaults_on_and_is_snapshotted():
+    cfg = Config()
+
+    assert cfg.fee_authority_enabled is True
+    assert cfg.snapshot().fee_authority_enabled is True
 
 
 def test_gate_defaults_enabled_and_transitions_once():
@@ -116,3 +128,124 @@ def test_concurrent_snapshot_waits_for_complete_transition():
     assert len(statuses) == 2
     assert statuses[0] == statuses[1]
     assert (statuses[0].enabled, statuses[0].generation) == (False, 1)
+
+
+@pytest.mark.parametrize(
+    ("new_value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("FALSE", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+    ],
+)
+def test_authority_callback_accepts_cln_boolean_spellings(new_value, expected):
+    mod = load_plugin_module()
+    initial = not expected
+    mod.config = Config(fee_authority_enabled=initial)
+    mod.fee_authority_gate = FeeAuthorityGate(
+        enabled=initial,
+        now_fn=lambda: 6000,
+    )
+
+    readback = mod._on_fee_authority_change(
+        mod.plugin,
+        FEE_AUTHORITY_OPTION,
+        new_value,
+    )
+
+    status = mod.fee_authority_gate.snapshot()
+    assert mod.config.fee_authority_enabled is expected
+    assert (status.enabled, status.generation, status.reason) == (
+        expected,
+        1,
+        "setconfig",
+    )
+    assert readback == (
+        f"{FEE_AUTHORITY_OPTION}={str(expected).lower()} generation=1"
+    )
+
+
+@pytest.mark.parametrize("invalid", ["", "maybe", 2, None])
+def test_authority_callback_rejects_invalid_input_without_mutation(invalid):
+    mod = load_plugin_module()
+    mod.config = Config(fee_authority_enabled=False)
+    mod.fee_authority_gate = FeeAuthorityGate(
+        enabled=False,
+        now_fn=lambda: 7000,
+    )
+    before = mod.fee_authority_gate.snapshot()
+
+    with pytest.raises(ValueError, match=f"{FEE_AUTHORITY_OPTION} must be a boolean"):
+        mod._on_fee_authority_change(
+            mod.plugin,
+            FEE_AUTHORITY_OPTION,
+            invalid,
+        )
+
+    assert mod.config.fee_authority_enabled is False
+    assert mod.fee_authority_gate.snapshot() is before
+
+
+def test_authority_callback_updates_config_and_gate_under_config_lock():
+    mod = load_plugin_module()
+    mod.config = Config(fee_authority_enabled=True)
+    mod.fee_authority_gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 8000)
+    callback_started = threading.Event()
+    callback_finished = threading.Event()
+    callback_errors = []
+
+    def disable():
+        callback_started.set()
+        try:
+            mod._on_fee_authority_change(
+                mod.plugin,
+                FEE_AUTHORITY_OPTION,
+                False,
+            )
+        except Exception as exc:
+            callback_errors.append(exc)
+        finally:
+            callback_finished.set()
+
+    mod.config._lock.acquire()
+    worker = threading.Thread(target=disable)
+    try:
+        worker.start()
+        assert callback_started.wait(timeout=1)
+        assert not callback_finished.wait(timeout=0.05)
+        assert mod.config.fee_authority_enabled is True
+        assert mod.fee_authority_gate.snapshot().enabled is True
+    finally:
+        mod.config._lock.release()
+
+    worker.join(timeout=1)
+    assert not worker.is_alive()
+    assert callback_errors == []
+    assert mod.config.fee_authority_enabled is False
+    assert mod.fee_authority_gate.snapshot().enabled is False
+
+
+def test_fee_authority_status_rpc_returns_positive_in_process_state(monkeypatch):
+    mod = load_plugin_module()
+    mod.fee_authority_gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 9000)
+    monkeypatch.setattr(mod.time, "time", lambda: 9010)
+
+    result = mod.revenue_fee_authority_status(mod.plugin)
+
+    assert result == {
+        "schema": "revenue_ops_fee_authority/v1",
+        "enabled": True,
+        "generation": 0,
+        "transitioned_at": 9000,
+        "observed_at": 9010,
+        "reason": "initial",
+    }

--- a/tests/test_fee_controller.py
+++ b/tests/test_fee_controller.py
@@ -21,6 +21,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from modules.policy_manager import FeeStrategy, RebalanceMode, PeerPolicy
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 class MockConfigSnapshot:
     """Mock ConfigSnapshot for testing."""
 
@@ -81,7 +83,7 @@ class TestPauseControl:
         cfg = Config(paused=True)
         mock_database.get_all_channel_states = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         adjustments = fc.adjust_all_fees()
         summary = fc.get_last_decision_summary()
@@ -131,7 +133,7 @@ class TestAdjustAllFeesSkipClassification:
         from modules.fee_controller import FeeController
 
         config = MagicMock(spec=Config)
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         cfg = MockConfigSnapshot(
             min_fee_ppm=1,
@@ -369,7 +371,7 @@ class TestRebalanceCostFloor:
         from modules.config import Config
 
         config = MagicMock(spec=Config)
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         channel_id = "123x456x0"
         peer_id = "02" + "a" * 64
@@ -400,7 +402,7 @@ class TestRebalanceCostFloor:
         from modules.config import Config
 
         config = MagicMock(spec=Config)
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         channel_id = "123x456x0"
         peer_id = "02" + "a" * 64
@@ -429,7 +431,7 @@ class TestRebalanceCostFloor:
         from modules.config import Config
 
         config = MagicMock(spec=Config)
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         channel_id = "123x456x0"
         peer_id = "02" + "a" * 64
@@ -452,7 +454,7 @@ class TestRebalanceCostFloor:
         from modules.config import Config
 
         config = MagicMock(spec=Config)
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         channel_id = "123x456x0"
         peer_id = "02" + "a" * 64
@@ -479,7 +481,7 @@ class TestRebalanceCostFloor:
         from modules.config import Config
 
         config = MagicMock(spec=Config)
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         channel_id = "123x456x0"
         peer_id = "02" + "a" * 64
@@ -503,7 +505,7 @@ class TestRebalanceCostFloor:
         from modules.config import Config
 
         config = MagicMock(spec=Config)
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         channel_id = "123x456x0"
         peer_id = "02" + "a" * 64
@@ -540,7 +542,7 @@ class TestRealizedCostFloorNoSuccessRateDivision:
         from modules.config import Config
 
         config = MagicMock(spec=Config)
-        return FeeController(mock_plugin, config, mock_database)
+        return FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
     def _cost_history(self, cost_ppm=100, n=5):
         """Return n cost records that average to cost_ppm per 1M sats."""
@@ -614,7 +616,7 @@ class TestAuditRound8Regressions:
         from modules.config import Config
 
         config = MagicMock(spec=Config)
-        return FeeController(mock_plugin, config, mock_database)
+        return FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
     # --- P1-1: Flow-adjusted ceiling cannot return 0 ---
 
@@ -735,7 +737,7 @@ class TestCalculateFloorOpener:
     def test_remote_opener_lower_floor(self, mock_plugin, mock_database):
         from modules.fee_controller import FeeController
         config = MagicMock()
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         chain_costs = {"open_cost_sats": 5000, "close_cost_sats": 3000, "sat_per_vbyte": 5.0}
         floor_local = fc._calculate_floor(5_000_000, chain_costs=chain_costs, opener="local")
@@ -751,7 +753,7 @@ class TestCalculateFloorOpener:
     def test_default_opener_is_local(self, mock_plugin, mock_database):
         from modules.fee_controller import FeeController
         config = MagicMock()
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         chain_costs = {"open_cost_sats": 5000, "close_cost_sats": 3000, "sat_per_vbyte": 5.0}
         floor_default = fc._calculate_floor(5_000_000, chain_costs=chain_costs)
@@ -767,7 +769,7 @@ class TestLastDecisionSummary:
         cfg = Config()
         mock_database.get_all_channel_states.return_value = []
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         adjustments = fc.adjust_all_fees()
         summary = fc.get_last_decision_summary()
@@ -794,6 +796,7 @@ class TestLastDecisionSummary:
             cfg,
             mock_database,
             temporary_fee_overlay_active=lambda cid: cid == channel_id,
+            fee_authority_gate=FeeAuthorityGate(),
         )
         fc._get_channels_info = MagicMock(return_value={
             channel_id: {"fee_proportional_millionths": 100}
@@ -840,7 +843,7 @@ class TestStaticStrategyExecution:
             {"channel_id": channel_id, "peer_id": peer_id, "state": "balanced"}
         ]
 
-        fc = FeeController(mock_plugin, cfg, mock_database, policy_manager=policy_manager)
+        fc = FeeController(mock_plugin, cfg, mock_database, policy_manager=policy_manager, fee_authority_gate=FeeAuthorityGate())
         fc._get_channels_info = MagicMock(return_value={
             channel_id: {
                 "channel_id": channel_id,

--- a/tests/test_fee_controller_audit_regressions.py
+++ b/tests/test_fee_controller_audit_regressions.py
@@ -37,12 +37,15 @@ from modules.fee_controller import (
 from modules.config import Config
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_fc(mock_plugin, mock_database, policy_manager=None):
     """Create a fee controller with mocked dependencies."""
     config = MagicMock(spec=Config)
     return FeeController(
         mock_plugin, config, mock_database,
         policy_manager=policy_manager,
+        fee_authority_gate=FeeAuthorityGate(),
     )
 
 

--- a/tests/test_fee_controller_pending_fixes.py
+++ b/tests/test_fee_controller_pending_fixes.py
@@ -49,9 +49,11 @@ from modules.config import Config
 from tests.plugin_test_utils import load_plugin_module
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_fc(mock_plugin, mock_database):
     config = MagicMock(spec=Config)
-    return FeeController(mock_plugin, config, mock_database)
+    return FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
 
 def _make_config_snapshot(**overrides):

--- a/tests/test_fee_cycle_capture_integration.py
+++ b/tests/test_fee_cycle_capture_integration.py
@@ -97,6 +97,8 @@ DECISION_CALL_CONTRACT = {
 }
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _decision_call_inventory(source):
     tree = ast.parse(source)
     inventory = {name: Counter() for name in DECISION_CALL_CONTRACT}
@@ -653,6 +655,7 @@ def _capture_controller(tmp_path, *, enabled=True, dry_run=True,
         temporary_fee_overlay_active=(
             (lambda _channel_id: overlay) if overlay_available else None
         ),
+        fee_authority_gate=FeeAuthorityGate(),
     )
     data_service = MagicMock()
     data_service.get_node_id.return_value = NODE_ID
@@ -1666,6 +1669,6 @@ def test_controller_manager_stays_default_off_with_malformed_config_path():
     config.db_path = object()
     config.fee_replay_capture_enabled = False
 
-    controller = FeeController(plugin, config, MagicMock())
+    controller = FeeController(plugin, config, MagicMock(), fee_authority_gate=FeeAuthorityGate())
 
     assert controller._fee_capture.read_manifest() == {}

--- a/tests/test_fee_cycle_optimizations.py
+++ b/tests/test_fee_cycle_optimizations.py
@@ -45,6 +45,8 @@ PEER_IDS = ["02" + c * 64 for c in "abc"]
 CHANNEL_IDS = ["100x1x0", "100x2x0", "100x3x0"]
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_config_snapshot(**overrides):
     defaults = {
         "paused": False,
@@ -124,7 +126,7 @@ def _setup_db(mock_database, now=None):
 def _make_cycle_fc(mock_plugin, mock_database):
     """Build a FeeController wired up for an end-to-end adjust_all_fees run."""
     config = MagicMock(spec=Config)
-    fc = FeeController(mock_plugin, config, mock_database)
+    fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
     cfg = _make_config_snapshot()
     fc.config.snapshot.return_value = cfg
     fc.config.dry_run = True  # set_channel_fee succeeds without RPC
@@ -423,7 +425,7 @@ class TestNeighborHelpers:
     def _make_fc_with_gossip(self, mock_plugin, mock_database, channels):
         mock_plugin.rpc.getinfo.return_value = {"id": "02our_node_id"}
         config = MagicMock(spec=Config)
-        fc = FeeController(mock_plugin, config, mock_database)
+        fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = MagicMock()
         fc.data_service.get_channels.return_value = {"channels": channels}
         fc.data_service.get_node_id.return_value = "02our_node_id"

--- a/tests/test_fee_intelligence_improvements.py
+++ b/tests/test_fee_intelligence_improvements.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock
 from modules.fee_controller import FeeController, GaussianThompsonState, ChannelFeeState
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_data_service(mock_plugin):
     """Build a data_service MagicMock that delegates to mock_plugin.rpc."""
     ds = MagicMock()
@@ -56,7 +58,7 @@ class TestNetworkInformedPriors:
                 {"fee_per_millionth": 800},
             ]
         }
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         result = fc._get_network_fee_prior("02peer", "123x1x0")
         assert result is not None
@@ -65,14 +67,14 @@ class TestNetworkInformedPriors:
 
     def test_prior_none_when_no_channels(self, mock_plugin, mock_config, mock_database):
         mock_plugin.rpc.listchannels.return_value = {"channels": []}
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         result = fc._get_network_fee_prior("02peer", "123x1x0")
         assert result is None
 
     def test_prior_none_on_rpc_failure(self, mock_plugin, mock_config, mock_database):
         mock_plugin.rpc.listchannels.side_effect = Exception("RPC error")
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         result = fc._get_network_fee_prior("02peer", "123x1x0")
         assert result is None
@@ -85,7 +87,7 @@ class TestNetworkInformedPriors:
                 {"fee_per_millionth": 50000},   # Too high
             ]
         }
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         result = fc._get_network_fee_prior("02peer", "123x1x0")
         assert result is not None
@@ -110,7 +112,7 @@ class TestRebalanceCostFloor:
 
     def test_cost_ppm_from_dest_ledger(self, mock_plugin, mock_config, mock_database):
         mock_database.get_channel_cost_history.return_value = self._history()
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         cost = fc._get_channel_rebalance_cost_ppm("123x1x0")
         assert cost == 500  # 500 sats / 1M sats * 1M = 500 PPM
         mock_database.get_last_rebalance_cost.assert_not_called()
@@ -124,7 +126,7 @@ class TestRebalanceCostFloor:
             # Ancient entry outside the window must not count
             {"cost_sats": 5_000, "amount_sats": 1_000, "timestamp": now - 90 * 86400},
         ]
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         cost = fc._get_channel_rebalance_cost_ppm("123x1x0")
         assert cost == 200  # (100+300) / 2M * 1M
 
@@ -132,36 +134,36 @@ class TestRebalanceCostFloor:
         """Sinks fill from inbound and dormant channels have no flow to
         recover against — nudging their price up opposes the drain logic."""
         mock_database.get_channel_cost_history.return_value = self._history()
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         assert fc._get_channel_rebalance_cost_ppm("123x1x0", flow_state="sink") == 0
         assert fc._get_channel_rebalance_cost_ppm("123x1x0", flow_state="dormant") == 0
 
     def test_cost_ppm_zero_when_no_history(self, mock_plugin, mock_config, mock_database):
         mock_database.get_channel_cost_history.return_value = []
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         cost = fc._get_channel_rebalance_cost_ppm("123x1x0")
         assert cost == 0
 
     def test_cost_ppm_zero_on_error(self, mock_plugin, mock_config, mock_database):
         mock_database.get_channel_cost_history.side_effect = Exception("DB error")
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         cost = fc._get_channel_rebalance_cost_ppm("123x1x0")
         assert cost == 0
 
     def test_cost_ppm_handles_zero_amount(self, mock_plugin, mock_config, mock_database):
         mock_database.get_channel_cost_history.return_value = self._history(amount=0)
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         cost = fc._get_channel_rebalance_cost_ppm("123x1x0")
         assert cost == 0
 
     def test_cost_ppm_handles_none_cost(self, mock_plugin, mock_config, mock_database):
         mock_database.get_channel_cost_history.return_value = self._history(cost=None)
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         cost = fc._get_channel_rebalance_cost_ppm("123x1x0")
         assert cost == 0
 
     def test_cost_ppm_no_database(self, mock_plugin, mock_config):
-        fc = FeeController(mock_plugin, mock_config, None)
+        fc = FeeController(mock_plugin, mock_config, None, fee_authority_gate=FeeAuthorityGate())
         cost = fc._get_channel_rebalance_cost_ppm("123x1x0")
         assert cost == 0
 
@@ -186,7 +188,7 @@ class TestFailedForwardObservation:
         return state
 
     def test_fee_failcode_adjusts_posterior(self, mock_plugin, mock_config, mock_database):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = self._seed_channel(fc)
 
         original_mean = state.posterior_mean
@@ -204,7 +206,7 @@ class TestFailedForwardObservation:
         self, mock_plugin, mock_config, mock_database
     ):
         """Some payloads carry only the symbolic failreason."""
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = self._seed_channel(fc)
 
         original_mean = state.posterior_mean
@@ -220,7 +222,7 @@ class TestFailedForwardObservation:
         change, not demand evidence. A raise on a busy channel used to emit
         ~50 nudges that moved the next sample ~99% of the way to 0.8x,
         systematically undoing every raise on the busiest channels."""
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = self._seed_channel(fc)
 
         fc._last_fee_apply_ts["123x1x0"] = int(time.time()) - 60
@@ -234,7 +236,7 @@ class TestFailedForwardObservation:
     def test_nudge_allowed_after_gossip_settle_window(
         self, mock_plugin, mock_config, mock_database
     ):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = self._seed_channel(fc)
 
         fc._last_fee_apply_ts["123x1x0"] = (
@@ -253,7 +255,7 @@ class TestFailedForwardObservation:
     ):
         """One nudge per channel per observation window — a burst of
         failures within one window is one datapoint, not fifty."""
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = self._seed_channel(fc)
 
         for _ in range(5):
@@ -269,7 +271,7 @@ class TestFailedForwardObservation:
     ):
         """A liquidity failure says nothing about our fee — the sender
         already chose our edge."""
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = self._seed_channel(fc)
 
         original_mean = state.posterior_mean
@@ -287,7 +289,7 @@ class TestFailedForwardObservation:
     ):
         """No usable failure reason at all (CLN's plain 'failed' status):
         drop the nudge entirely."""
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = self._seed_channel(fc)
 
         original_mean = state.posterior_mean
@@ -297,29 +299,29 @@ class TestFailedForwardObservation:
         assert state.posterior_bias == []
 
     def test_failed_forward_no_crash_missing_state(self, mock_plugin, mock_config, mock_database):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         # No state for this channel — should not crash
         fc.record_failed_forward("999x1x0", 500, failcode=self.WIRE_FEE_INSUFFICIENT)
 
     def test_failed_forward_no_crash_zero_fee(self, mock_plugin, mock_config, mock_database):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         # Should not crash
         fc.record_failed_forward("123x1x0", 0, failcode=self.WIRE_FEE_INSUFFICIENT)
 
     def test_failed_forward_no_crash_empty_channel_id(self, mock_plugin, mock_config, mock_database):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         # Should not crash
         fc.record_failed_forward("", 500, failcode=self.WIRE_FEE_INSUFFICIENT)
 
     def test_failed_forward_no_crash_garbage_failcode(self, mock_plugin, mock_config, mock_database):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = self._seed_channel(fc)
         original_mean = state.posterior_mean
         fc.record_failed_forward("123x1x0", 500, failcode="not-a-number")
         assert state.posterior_mean == original_mean
 
     def test_failed_forward_preserves_min_std(self, mock_plugin, mock_config, mock_database):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         state = GaussianThompsonState()
         state.posterior_mean = 500.0
         state.posterior_std = float(GaussianThompsonState.MIN_STD)
@@ -341,20 +343,20 @@ class TestConfidenceScaledBlend:
     confidence boost."""
 
     def test_high_confidence_increases_blend(self, mock_plugin, mock_config, mock_database):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         high_var_ratio = fc._get_target_blend_ratio(False, True, posterior_std=250.0)
         confident_ratio = fc._get_target_blend_ratio(False, False, posterior_std=20.0)
         assert confident_ratio > high_var_ratio
 
     def test_blend_capped_at_sixty_percent(self, mock_plugin, mock_config, mock_database):
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         ratio = fc._get_target_blend_ratio(False, False, posterior_std=1.0)
         assert ratio <= 0.60
 
     def test_tight_posterior_under_sparse_flag_gets_boost(self, mock_plugin, mock_config, mock_database):
         """Prior design stuck sparse channels at 0.20 even with tight posterior.
         Phase A.2: posterior_std drives the ratio; sparse flag no longer caps."""
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         ratio = fc._get_target_blend_ratio(False, True, posterior_std=10.0)
         assert ratio == 0.60  # Tight posterior -> fast convergence regardless of flag
 
@@ -371,7 +373,7 @@ class TestNeighborFeeAwareness:
                 {"source": "02node5", "fee_per_millionth": 500, "active": True},
             ]
         }
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         median = fc._get_neighbor_fee_median("02peer123")
         assert median == 200
@@ -383,7 +385,7 @@ class TestNeighborFeeAwareness:
                 {"source": "02node1", "fee_per_millionth": 100, "active": True},
             ]
         }
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         assert fc._get_neighbor_fee_median("02peer") is None
 
@@ -397,7 +399,7 @@ class TestNeighborFeeAwareness:
                 {"source": "02node3", "fee_per_millionth": 300, "active": True},
             ]
         }
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         median = fc._get_neighbor_fee_median("02peer")
         assert median == 200  # Our 999 excluded
@@ -408,7 +410,7 @@ class TestNeighborFeeAwareness:
             {"source": f"02node{i}", "fee_per_millionth": 100 + i * 50, "active": True}
             for i in range(5)
         ]}
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         fc._get_neighbor_fee_median("02peer")
         fc._get_neighbor_fee_median("02peer")
@@ -425,7 +427,7 @@ class TestNeighborFeeAwareness:
                 {"source": "02node4", "fee_per_millionth": 400, "active": True},
             ]
         }
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         median = fc._get_neighbor_fee_median("02peer")
         assert median == 300  # Inactive node2 excluded; [100, 300, 400] -> 300
@@ -441,14 +443,14 @@ class TestNeighborFeeAwareness:
                 {"source": "02node5", "fee_per_millionth": 50000, "active": True},
             ]
         }
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         median = fc._get_neighbor_fee_median("02peer")
         assert median == 200  # 0 and 50000 filtered out; [100, 200, 300] -> 200
 
     def test_neighbor_none_on_rpc_error(self, mock_plugin, mock_config, mock_database):
         mock_plugin.rpc.getinfo.side_effect = Exception("RPC error")
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         assert fc._get_neighbor_fee_median("02peer") is None
 
@@ -459,7 +461,7 @@ class TestNeighborFeeAwareness:
             {"source": f"02node{i}", "fee_per_millionth": 100 + i * 50, "active": True}
             for i in range(5)
         ]}
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         # Fill cache with 501 stale entries
         old_ts = time.time() - 7200  # 2 hours old

--- a/tests/test_fee_node_drain_bias.py
+++ b/tests/test_fee_node_drain_bias.py
@@ -200,6 +200,7 @@ import random as _random
 from unittest.mock import MagicMock as _MagicMock
 
 from modules.fee_controller import FeeController as _Controller
+from modules.fee_authority import FeeAuthorityGate
 from modules.config import Config as _Config
 
 _PEER_ID = "02" + "b" * 64
@@ -293,7 +294,7 @@ def _make_node_bias_fc(mock_plugin, mock_database, *, node_drain_bias_enabled,
     reshaped channel dict, mirroring how compute_node_receivable_ratio
     consumes raw to_us_msat/total_msat/state fields."""
     config = _MagicMock(spec=_Config)
-    fc = _Controller(mock_plugin, config, mock_database)
+    fc = _Controller(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
     cfg = _node_bias_config_snapshot(node_drain_bias_enabled=node_drain_bias_enabled)
     fc.config.snapshot.return_value = cfg
 

--- a/tests/test_fee_pipeline_composition.py
+++ b/tests/test_fee_pipeline_composition.py
@@ -40,6 +40,8 @@ CHANNEL_ID = "123x456x0"
 PEER_ID = "02" + "a" * 64
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_config_snapshot(**overrides):
     defaults = {
         'min_fee_ppm': 10,
@@ -64,7 +66,7 @@ def _make_config_snapshot(**overrides):
 def _make_fc(mock_plugin, mock_database, **cfg_overrides):
     """Fee controller with the full DTS-path database mocks."""
     config = MagicMock(spec=Config)
-    fc = FeeController(mock_plugin, config, mock_database)
+    fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
     cfg = _make_config_snapshot(**cfg_overrides)
     fc.config.snapshot.return_value = cfg

--- a/tests/test_fee_setting_execution.py
+++ b/tests/test_fee_setting_execution.py
@@ -116,6 +116,126 @@ def _setchannel_kwargs(mock_plugin):
     return mock_plugin.rpc.setchannel.call_args.kwargs
 
 
+def _disabled_fee_authority_gate(now: int = 11_000):
+    from modules.fee_authority import FeeAuthorityGate
+
+    gate = FeeAuthorityGate(enabled=True, now_fn=lambda: now)
+    gate.set_enabled(False, reason="setconfig")
+    return gate
+
+
+def _blocked_fee_result(channel_id: str, fee_ppm: int, now: int = 11_000):
+    return {
+        "success": False,
+        "channel_id": channel_id,
+        "fee_ppm": fee_ppm,
+        "message": "Fee authority disabled",
+        "status": "blocked",
+        "reason": "fee_authority_disabled",
+        "operation": "set_channel_fee",
+        "generation": 1,
+        "transitioned_at": now,
+    }
+
+
+class TestFeeAuthorityExecutionBoundary:
+    def test_constructor_accepts_shared_fee_authority_gate(
+        self, mock_plugin, mock_database
+    ):
+        from modules.config import Config
+        from modules.fee_controller import FeeController
+
+        gate = _disabled_fee_authority_gate()
+        controller = FeeController(
+            mock_plugin,
+            Config(),
+            mock_database,
+            fee_authority_gate=gate,
+        )
+
+        assert controller.fee_authority_gate is gate
+
+    def test_disabled_gate_prevents_manual_state_and_rpc_mutation(
+        self, mock_plugin, mock_database
+    ):
+        from modules.config import Config
+        from modules.fee_controller import ChannelCycleState, ChannelFeeState, FeeController
+
+        channel_id = "123x456x0"
+        peer_id = "02" + "a" * 64
+        cfg = Config(min_fee_ppm=10, max_fee_ppm=5000, dry_run=False)
+        controller = FeeController(mock_plugin, cfg, mock_database)
+        controller.fee_authority_gate = _disabled_fee_authority_gate()
+        controller.data_service = _make_data_service(mock_plugin)
+        controller._cycle_states[channel_id] = ChannelCycleState(
+            is_sleeping=True,
+            sleep_until=99_999,
+            stable_cycles=4,
+        )
+        controller._channel_fee_states[channel_id] = ChannelFeeState(
+            is_sleeping=True,
+            sleep_until=99_999,
+            stable_cycles=4,
+        )
+        mock_plugin.rpc.setchannel = MagicMock(return_value={})
+
+        result = controller.set_channel_fee(
+            channel_id,
+            125,
+            manual=True,
+            channel_info={
+                "short_channel_id": channel_id,
+                "peer_id": peer_id,
+                "fee_proportional_millionths": 100,
+            },
+        )
+
+        assert result == _blocked_fee_result(channel_id, 125)
+        assert controller._cycle_states[channel_id].is_sleeping is True
+        assert controller._cycle_states[channel_id].sleep_until == 99_999
+        assert controller._cycle_states[channel_id].stable_cycles == 4
+        assert controller._channel_fee_states[channel_id].is_sleeping is True
+        assert controller._channel_fee_states[channel_id].sleep_until == 99_999
+        assert controller._channel_fee_states[channel_id].stable_cycles == 4
+        mock_database.update_fee_strategy_state.assert_not_called()
+        controller.data_service.set_channel.assert_not_called()
+
+    def test_disabled_gate_prevents_governor_and_dynamic_htlcmax_rpc_work(
+        self, mock_plugin, mock_database
+    ):
+        from modules.config import Config
+        from modules.fee_controller import FeeController
+
+        channel_id = "123x456x0"
+        peer_id = "02" + "a" * 64
+        cfg = Config(min_fee_ppm=10, max_fee_ppm=5000, dry_run=False)
+        controller = FeeController(mock_plugin, cfg, mock_database)
+        controller.fee_authority_gate = _disabled_fee_authority_gate()
+        controller.data_service = _make_data_service(mock_plugin)
+        controller._fee_governor_enabled = MagicMock(return_value=True)
+        controller._governed_authorize_fee_broadcast = MagicMock(
+            return_value=(True, "authorized")
+        )
+        mock_plugin.rpc.setchannel = MagicMock(return_value={})
+
+        result = controller.set_channel_fee(
+            channel_id,
+            125,
+            manual=False,
+            htlcmax_msat=21_000_000,
+            channel_info={
+                "short_channel_id": channel_id,
+                "peer_id": peer_id,
+                "fee_proportional_millionths": 100,
+            },
+        )
+
+        assert result == _blocked_fee_result(channel_id, 125)
+        controller._fee_governor_enabled.assert_not_called()
+        controller._governed_authorize_fee_broadcast.assert_not_called()
+        controller.data_service.set_channel.assert_not_called()
+
+
 class TestChannelInfoShaping:
     def test_get_channels_info_preserves_htlc_minimum_and_maximum_msat(self, mock_plugin, mock_database):
         from modules.config import Config

--- a/tests/test_fee_setting_execution.py
+++ b/tests/test_fee_setting_execution.py
@@ -10,6 +10,8 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_data_service(mock_plugin):
     """Build a data_service MagicMock that delegates to mock_plugin.rpc.
 
@@ -148,7 +150,7 @@ class TestFeeAuthorityExecutionBoundary:
         gate = _disabled_fee_authority_gate()
         controller = FeeController(
             mock_plugin,
-            Config(),
+            Config(fee_authority_enabled=False),
             mock_database,
             fee_authority_gate=gate,
         )
@@ -163,9 +165,19 @@ class TestFeeAuthorityExecutionBoundary:
 
         channel_id = "123x456x0"
         peer_id = "02" + "a" * 64
-        cfg = Config(min_fee_ppm=10, max_fee_ppm=5000, dry_run=False)
-        controller = FeeController(mock_plugin, cfg, mock_database)
-        controller.fee_authority_gate = _disabled_fee_authority_gate()
+        cfg = Config(
+            min_fee_ppm=10,
+            max_fee_ppm=5000,
+            dry_run=False,
+            fee_authority_enabled=False,
+        )
+        gate = _disabled_fee_authority_gate()
+        controller = FeeController(
+            mock_plugin,
+            cfg,
+            mock_database,
+            fee_authority_gate=gate,
+        )
         controller.data_service = _make_data_service(mock_plugin)
         controller._cycle_states[channel_id] = ChannelCycleState(
             is_sleeping=True,
@@ -208,9 +220,19 @@ class TestFeeAuthorityExecutionBoundary:
 
         channel_id = "123x456x0"
         peer_id = "02" + "a" * 64
-        cfg = Config(min_fee_ppm=10, max_fee_ppm=5000, dry_run=False)
-        controller = FeeController(mock_plugin, cfg, mock_database)
-        controller.fee_authority_gate = _disabled_fee_authority_gate()
+        cfg = Config(
+            min_fee_ppm=10,
+            max_fee_ppm=5000,
+            dry_run=False,
+            fee_authority_enabled=False,
+        )
+        gate = _disabled_fee_authority_gate()
+        controller = FeeController(
+            mock_plugin,
+            cfg,
+            mock_database,
+            fee_authority_gate=gate,
+        )
         controller.data_service = _make_data_service(mock_plugin)
         controller._fee_governor_enabled = MagicMock(return_value=True)
         controller._governed_authorize_fee_broadcast = MagicMock(
@@ -255,7 +277,7 @@ class TestChannelInfoShaping:
             htlc_maximum_msat=advertised_htlc_maximum_msat,
         )
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         channel_info = fc._get_channels_info()[channel_id]
 
@@ -280,7 +302,7 @@ class TestChannelInfoShaping:
             maximum_htlc_out_msat="21000000msat",
         )
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         channel_info = fc._get_channels_info()[channel_id]
 
@@ -307,7 +329,7 @@ class TestSetChannelFeeLimits:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         fc.set_channel_fee(channel_id, 1, manual=True, enforce_limits=True)
@@ -333,7 +355,7 @@ class TestSetChannelFeeLimits:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         fc.set_channel_fee(channel_id, 1, manual=True, enforce_limits=False)
@@ -360,7 +382,7 @@ class TestSetChannelFeeLimits:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         # Mirror the revenue-set-fee force=true call path: manual operator set,
@@ -389,7 +411,7 @@ class TestSetChannelFeeLimits:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         result = fc.set_channel_fee("123:456:0", 125, manual=True)
@@ -417,7 +439,7 @@ class TestSetChannelFeeLimits:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         result = fc.set_channel_fee(full_channel_id, 125, manual=True)
@@ -445,7 +467,7 @@ class TestSetChannelFeeLimits:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         fc._cycle_states[channel_id] = ChannelCycleState(
             last_fee_ppm=100,
@@ -494,7 +516,7 @@ class TestSetChannelFeeLimits:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         result = fc.set_channel_fee(peer_id, 125, manual=True)
@@ -518,7 +540,7 @@ class TestSetChannelFeeHtlcMin:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         return fc
 
@@ -595,7 +617,7 @@ class TestGossipRefreshExecution:
         mock_database.record_fee_change = MagicMock()
         mock_database.get_last_forward_time.return_value = int(time.time()) - 86400 * 2
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         # Provide a real-ish state and ensure the fee change will be applied.
@@ -626,7 +648,7 @@ class TestBoundedExplorationEndToEnd:
         from modules.fee_controller import FeeController
 
         cfg = Config(min_fee_ppm=40, max_fee_ppm=5000, base_fee_msat=0, dry_run=False)
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         target = fc._get_exploration_fee_target(
             current_fee_ppm=42,
@@ -642,7 +664,7 @@ class TestBoundedExplorationEndToEnd:
         from modules.fee_controller import FeeController
 
         cfg = Config(min_fee_ppm=40, max_fee_ppm=5000, base_fee_msat=0, dry_run=False)
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
 
         target = fc._get_exploration_fee_target(
             current_fee_ppm=400,
@@ -690,7 +712,7 @@ class TestBoundedExplorationEndToEnd:
         mock_database.get_channel_cost_history.return_value = []
         mock_database.get_historical_inbound_fee_ppm.return_value = None
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         channel_info = {
@@ -748,7 +770,7 @@ class TestBoundedExplorationEndToEnd:
         mock_database.get_channel_cost_history.return_value = []
         mock_database.get_historical_inbound_fee_ppm.return_value = None
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         channel_info = {
@@ -792,7 +814,7 @@ class TestBoundedExplorationEndToEnd:
         mock_database.get_fee_strategy_state.return_value = _fee_strategy_state_dict()
         mock_database.record_fee_change = MagicMock()
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         fc._cycle_states[channel_id] = ChannelCycleState(
             last_fee_ppm=200,
@@ -841,7 +863,8 @@ class TestSetInitialFee:
         mock_database.record_fee_change = MagicMock()
 
         fc = FeeController(
-            mock_plugin, cfg, mock_database, policy_manager
+            mock_plugin, cfg, mock_database, policy_manager,
+            fee_authority_gate=FeeAuthorityGate(),
         )
         fc.data_service = _make_data_service(mock_plugin)
         return fc
@@ -1064,7 +1087,7 @@ class TestSetInitialFeePersistentPriorSeeding:
 
         mock_plugin.rpc.listpeerchannels.side_effect = fake_listpeerchannels
 
-        fc = FeeController(mock_plugin, cfg, mock_database)
+        fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
 
         fc._get_network_fee_prior = MagicMock(return_value=network_prior)

--- a/tests/test_fee_snapshot_adoption.py
+++ b/tests/test_fee_snapshot_adoption.py
@@ -30,8 +30,10 @@ PEER_B = "03" + "b" * 64
 NOW = 1_752_400_000
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _fc():
-    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock())
+    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock(), fee_authority_gate=FeeAuthorityGate())
     cfg = MagicMock()
     cfg.snapshot.return_value = SimpleNamespace(
         econ_governor_fees_enabled=True, paused=False,

--- a/tests/test_flow_audit_fixes.py
+++ b/tests/test_flow_audit_fixes.py
@@ -15,6 +15,8 @@ import pytest
 from unittest.mock import MagicMock
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_analyzer(source_threshold=0.05, sink_threshold=-0.05):
     from modules.flow_analysis import FlowAnalyzer
 
@@ -464,7 +466,7 @@ class TestF6DormantVocabulary:
         plugin = MagicMock()
         config = MagicMock(spec=Config)
         db = MagicMock()
-        fc = FeeController(plugin, config, db)
+        fc = FeeController(plugin, config, db, fee_authority_gate=FeeAuthorityGate())
 
         assert fc._get_rebalance_cost_floor("100x1x0", "peer", "dormant") is None
         db.get_channel_cost_history.assert_not_called()

--- a/tests/test_forward_hot_path.py
+++ b/tests/test_forward_hot_path.py
@@ -11,6 +11,9 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from modules.fee_authority import FeeAuthorityGate
 from tests.plugin_test_utils import load_plugin_module
 
 
@@ -36,6 +39,11 @@ def _module():
     mod.plugin.log = MagicMock()
     mod.fee_controller = None
     return mod
+
+
+def _disable_fee_authority(mod):
+    mod.fee_authority_gate = FeeAuthorityGate(enabled=True, now_fn=lambda: 10_000)
+    mod.fee_authority_gate.set_enabled(False, reason="setconfig")
 
 
 class TestForwardWriteCoalescing:
@@ -108,6 +116,55 @@ class TestForwardWriteCoalescing:
         db.update_peer_reputation.assert_called_once_with(PEER, is_success=False)
         db.record_forward_and_reputation.assert_not_called()
         db.record_forward.assert_not_called()
+
+    @pytest.mark.parametrize("status", ["failed", "local_failed"])
+    def test_disabled_authority_blocks_failed_forward_fee_trigger(self, status):
+        mod = _module()
+        _disable_fee_authority(mod)
+        db = MagicMock(spec=[
+            "record_forward_and_reputation", "record_forward", "update_peer_reputation",
+        ])
+        mod.database = db
+        mod._resolve_scid_to_peer = MagicMock(return_value=PEER)
+        mod.fee_controller = MagicMock()
+        mod.fee_controller.is_fee_relevant_failure.return_value = True
+        mod.fee_controller._state_lock.acquire.return_value = True
+        mod.fee_controller._channel_fee_states = {
+            "200x2x0": MagicMock(last_fee_ppm=250),
+        }
+
+        event = _settled_event()
+        event.update({
+            "status": status,
+            "failcode": 0x1000 | 12,
+            "failreason": "WIRE_FEE_INSUFFICIENT",
+        })
+        mod._on_forward_event_impl(event, mod.plugin)
+
+        mod.fee_controller.is_fee_relevant_failure.assert_not_called()
+        mod.fee_controller._state_lock.acquire.assert_not_called()
+        mod.fee_controller.record_failed_forward.assert_not_called()
+        if status == "failed":
+            db.update_peer_reputation.assert_called_once_with(
+                PEER, is_success=False
+            )
+
+    def test_disabled_authority_keeps_settled_forward_accounting_live(self):
+        mod = _module()
+        _disable_fee_authority(mod)
+        db = MagicMock(spec=[
+            "record_forward_and_reputation", "record_forward", "update_peer_reputation",
+        ])
+        mod.database = db
+        mod._resolve_scid_to_peer = MagicMock(return_value=PEER)
+
+        mod._on_forward_event_impl(_settled_event(), mod.plugin)
+
+        db.record_forward_and_reputation.assert_called_once()
+        forward, peer_id, success = db.record_forward_and_reputation.call_args.args
+        assert (forward["out_channel"], peer_id, success) == (
+            "200x2x0", PEER, True
+        )
 
 
 class TestScidNegativeCache:

--- a/tests/test_gossip_cache.py
+++ b/tests/test_gossip_cache.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, call
 from modules.fee_controller import FeeController
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_data_service(mock_plugin):
     """Build a data_service MagicMock that delegates to mock_plugin.rpc."""
     ds = MagicMock()
@@ -48,7 +50,7 @@ def mock_database():
 @pytest.fixture
 def fc(mock_plugin, mock_config, mock_database):
     mock_plugin.rpc.getinfo.return_value = {"id": "02our_node_id"}
-    controller = FeeController(mock_plugin, mock_config, mock_database)
+    controller = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
     controller.data_service = _make_data_service(mock_plugin)
     return controller
 
@@ -71,7 +73,7 @@ class TestGetOurId:
 
     def test_handles_empty_id(self, mock_plugin, mock_config, mock_database):
         mock_plugin.rpc.getinfo.return_value = {}
-        fc = FeeController(mock_plugin, mock_config, mock_database)
+        fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = _make_data_service(mock_plugin)
         assert fc._get_our_id() == ""
 

--- a/tests/test_governed_fees.py
+++ b/tests/test_governed_fees.py
@@ -15,8 +15,10 @@ from modules.fee_controller import FeeController
 SCID = "111x222x0"
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _fc(governed=True, paused=False):
-    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock())
+    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock(), fee_authority_gate=FeeAuthorityGate())
     cfg = MagicMock()
     cfg.snapshot.return_value = SimpleNamespace(
         econ_governor_fees_enabled=governed, paused=paused)
@@ -25,7 +27,7 @@ def _fc(governed=True, paused=False):
 
 
 def test_flag_check_is_strict():
-    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock())
+    fc = FeeController(MagicMock(), MagicMock(spec=Config), MagicMock(), fee_authority_gate=FeeAuthorityGate())
     fc.config = MagicMock()  # truthy attrs
     assert fc._fee_governor_enabled() is False
     assert _fc(governed=True)._fee_governor_enabled() is True

--- a/tests/test_operator_surface.py
+++ b/tests/test_operator_surface.py
@@ -6,6 +6,19 @@ from modules.config import Config
 from tests.plugin_test_utils import load_plugin_module
 
 
+FEE_AUTHORITY_OPTION = "revenue-ops-fee-authority-enabled"
+
+
+def test_fee_authority_plugin_option_is_dynamic_boolean_and_default_on():
+    mod = load_plugin_module()
+
+    option = mod.plugin.options[FEE_AUTHORITY_OPTION]
+    assert option["default"] is True
+    assert option["opt_type"] == "bool"
+    assert option["dynamic"] is True
+    assert option["on_change"] is mod._on_fee_authority_change
+
+
 def test_public_runtime_keys_are_safety_only():
     cfg = Config()
 
@@ -82,6 +95,7 @@ def test_public_runtime_keys_are_safety_only():
 def test_internal_knobs_are_not_public():
     cfg = Config()
 
+    assert "fee_authority_enabled" not in cfg.public_runtime_keys()
     assert "enable_vegas_reflex" not in cfg.public_runtime_keys()
     assert "thompson_prior_std_fee" not in cfg.public_runtime_keys()
     assert "askrene_layers" not in cfg.public_runtime_keys()
@@ -264,6 +278,22 @@ def _run_init_with_stubbed_dependencies(
 
     mod.init(options, {}, mod.plugin)
     return mod.config
+
+
+def test_fee_authority_option_is_parsed_during_init_and_initializes_gate(monkeypatch):
+    mod = load_plugin_module()
+
+    cfg = _run_init_with_stubbed_dependencies(
+        mod,
+        monkeypatch,
+        {FEE_AUTHORITY_OPTION: "false"},
+    )
+
+    assert cfg.fee_authority_enabled is False
+    status = mod.fee_authority_gate.snapshot()
+    assert status.enabled is False
+    assert status.generation == 1
+    assert status.reason == "init"
 
 
 def test_planner_execute_closes_plugin_option_defaults_false():

--- a/tests/test_p8_002_floor_stall_after_risk.py
+++ b/tests/test_p8_002_floor_stall_after_risk.py
@@ -14,11 +14,13 @@ so it multiplies whichever term wins.
 from unittest.mock import MagicMock
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _fee_controller(mock_plugin, mock_database):
     from modules.fee_controller import FeeController
 
     config = MagicMock()
-    return FeeController(mock_plugin, config, mock_database)
+    return FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
 
 
 def test_stall_multiplier_applies_after_risk_premium(mock_plugin, mock_database):

--- a/tests/test_policy_change_wake.py
+++ b/tests/test_policy_change_wake.py
@@ -31,11 +31,13 @@ CHAN_A2 = "111x2x0"
 CHAN_B1 = "222x1x0"
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_fc(database=None):
     plugin = MagicMock()
     config = MagicMock(spec=Config)
     db = database or MagicMock()
-    return FeeController(plugin, config, db)
+    return FeeController(plugin, config, db, fee_authority_gate=FeeAuthorityGate())
 
 
 def _sleeping_cycle():

--- a/tests/test_prior_reseed.py
+++ b/tests/test_prior_reseed.py
@@ -22,6 +22,8 @@ CHANNEL = "123x456x0"
 PEER = "02" + "a" * 64
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 @pytest.fixture
 def mock_plugin():
     p = MagicMock()
@@ -46,7 +48,7 @@ def mock_database():
 
 
 def _make_fc(mock_plugin, mock_config, mock_database, gossip_channels=None):
-    fc = FeeController(mock_plugin, mock_config, mock_database)
+    fc = FeeController(mock_plugin, mock_config, mock_database, fee_authority_gate=FeeAuthorityGate())
     fc.data_service = MagicMock()
     fc.data_service.get_channels.return_value = {
         "channels": gossip_channels or []

--- a/tests/test_risk_profiles.py
+++ b/tests/test_risk_profiles.py
@@ -12,6 +12,8 @@ Safety architecture under test:
   field cannot ship unclassified).
 """
 import dataclasses
+import re
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -29,6 +31,18 @@ from modules.risk_profiles import (
     PROFILE_NAMES,
     resolve_profile,
 )
+
+
+COMPATIBILITY_CATALOG = (
+    Path(__file__).resolve().parents[1]
+    / "docs/refactor/phase0/compatibility-catalog.md"
+)
+
+
+def _catalog_default(field):
+    if field.default is not dataclasses.MISSING:
+        return repr(field.default)
+    return f"factory:{field.default_factory.__name__}"
 
 
 def _load(overrides):
@@ -56,6 +70,31 @@ class TestClassificationCoverage:
     def test_deprecated_key_classified(self):
         assert FIELD_CLASSIFICATION["rebalance_min_profit"] == \
             "deprecated_transition"
+
+    def test_compatibility_catalog_matches_config_surface(self):
+        text = COMPATIBILITY_CATALOG.read_text()
+        heading = re.search(
+            r"^### Full Config dataclass surface \((\d+) fields with defaults\)$",
+            text,
+            re.MULTILINE,
+        )
+        assert heading is not None
+        rows = re.findall(
+            r"^\| `([^`]+)` \| `([^`]*)` \| *(yes)? *\|$",
+            text[heading.end():],
+            re.MULTILINE,
+        )
+        expected = [
+            (
+                field.name,
+                _catalog_default(field),
+                "yes" if field.name in PUBLIC_RUNTIME_KEYS else "",
+            )
+            for field in dataclasses.fields(Config)
+        ]
+
+        assert int(heading.group(1)) == len(expected)
+        assert rows == expected
 
 
 class TestBundleSafety:

--- a/tests/test_rpc_surface_inventory.py
+++ b/tests/test_rpc_surface_inventory.py
@@ -12,7 +12,8 @@ PLUGIN_PY = pathlib.Path(__file__).resolve().parent.parent / "cl-revenue-ops.py"
 
 EXPECTED_RPC_METHODS = frozenset({
     "revenue-rebalance-cycle", "revenue-status", "revenue-rebalance-debug",
-    "revenue-fee-debug", "revenue-fee-cycle", "revenue-analyze",
+    "revenue-fee-debug", "revenue-fee-cycle", "revenue-fee-authority-status",
+    "revenue-analyze",
     "revenue-wake-all", "revenue-capacity-report", "revenue-planner-status",
     "revenue-lnplus-status", "revenue-lnplus-breaker-clear",
     "revenue-lnplus-abandon", "revenue-lnplus-backfill",
@@ -62,5 +63,6 @@ def test_expected_count():
     # 64 at baseline 5e8f747; + econ-shadow diagnostics (no compat
     # promise yet): revenue-econ-snapshot (Phase 1), revenue-econ-
     # reconcile (Phase 2B), revenue-econ-cycle (Workstream H shadow),
-    # revenue-profile-preview (PR 8, read-only risk-profile diff).
-    assert len(EXPECTED_RPC_METHODS) == 68
+    # revenue-profile-preview (PR 8, read-only risk-profile diff), and
+    # revenue-fee-authority-status (Python fee-authority handoff status).
+    assert len(EXPECTED_RPC_METHODS) == 69

--- a/tests/test_thompson_state_nested_format.py
+++ b/tests/test_thompson_state_nested_format.py
@@ -45,9 +45,11 @@ CHANNEL_ID = "100x1x0"
 PEER_ID = "02" + "a" * 64
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_fc(mock_plugin, mock_database):
     config = MagicMock(spec=Config)
-    fc = FeeController(mock_plugin, config, mock_database)
+    fc = FeeController(mock_plugin, config, mock_database, fee_authority_gate=FeeAuthorityGate())
     # Real Database returns a defaults dict for unknown channels, never None
     mock_database.get_fee_strategy_state.return_value = {
         "channel_id": CHANNEL_ID, "v2_state_json": "{}", "last_update": 0,

--- a/tests/test_upgrade_a_adaptive_base_fee.py
+++ b/tests/test_upgrade_a_adaptive_base_fee.py
@@ -14,6 +14,8 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _make_data_service(mock_plugin):
     ds = MagicMock()
     ds.get_peer_channels.side_effect = lambda peer_id=None, **kw: (
@@ -82,7 +84,7 @@ def test_policy_off_uses_legacy_base_fee_msat(mock_plugin, mock_database):
     mock_database.get_fee_strategy_state.return_value = _strategy_state()
     mock_database.record_fee_change = MagicMock()
 
-    fc = FeeController(mock_plugin, cfg, mock_database)
+    fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
     fc.data_service = _make_data_service(mock_plugin)
 
     fc.set_channel_fee(scid, 200, manual=True)
@@ -109,7 +111,7 @@ def test_policy_adaptive_uses_legacy_base_fee(mock_plugin, mock_database):
     mock_database.get_fee_strategy_state.return_value = _strategy_state()
     mock_database.record_fee_change = MagicMock()
 
-    fc = FeeController(mock_plugin, cfg, mock_database)
+    fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
     fc.data_service = _make_data_service(mock_plugin)
 
     fc.set_channel_fee(scid, 200, manual=True)
@@ -137,7 +139,7 @@ def test_explicit_override_beats_policy(mock_plugin, mock_database):
     mock_database.get_fee_strategy_state.return_value = _strategy_state()
     mock_database.record_fee_change = MagicMock()
 
-    fc = FeeController(mock_plugin, cfg, mock_database)
+    fc = FeeController(mock_plugin, cfg, mock_database, fee_authority_gate=FeeAuthorityGate())
     fc.data_service = _make_data_service(mock_plugin)
 
     fc.set_channel_fee(scid, 200, manual=True, base_fee_msat_override=5555)

--- a/tools/audit/stress_concurrency.py
+++ b/tools/audit/stress_concurrency.py
@@ -92,6 +92,8 @@ from tests.plugin_test_utils import load_plugin_module  # noqa: E402
 # ---------------------------------------------------------------------------
 # Mock substrate
 # ---------------------------------------------------------------------------
+from modules.fee_authority import FeeAuthorityGate
+
 class _SafePluginMock:
     """Minimal ThreadSafePluginProxy stand-in: .log + .rpc, both thread-safe."""
 
@@ -266,7 +268,7 @@ class StressHarness:
             pm = mod.PolicyManager(db, safe_plugin)
             mod.profitability_analyzer = pa
             mod.policy_manager = pm
-            mod.fee_controller = mod.FeeController(safe_plugin, cfg, db, pm, pa)
+            mod.fee_controller = mod.FeeController(safe_plugin, cfg, db, pm, pa, fee_authority_gate=FeeAuthorityGate())
             self._probe_loop("fee", mod.run_fee_adjustment)
         except Exception as exc:
             mod.fee_controller = None

--- a/tools/perf/cycle_driver.py
+++ b/tools/perf/cycle_driver.py
@@ -20,6 +20,8 @@ N_CHANNELS = 36
 DAY = 86_400
 
 
+from modules.fee_authority import FeeAuthorityGate
+
 def _scids(n: int) -> List[str]:
     return [f"{800000 + i}x{i}x0" for i in range(n)]
 
@@ -146,7 +148,7 @@ def build_stack(database) -> Dict[str, Any]:
     stack["profitability"] = profitability
 
     try:
-        fc = FeeController(plugin, config, database, policy_manager, profitability)
+        fc = FeeController(plugin, config, database, policy_manager, profitability, fee_authority_gate=FeeAuthorityGate())
         fc.data_service = data_service
         stack["fee_controller"] = fc
     except Exception:


### PR DESCRIPTION
## Summary

- add a default-on, dynamically configurable Python fee-authority gate and positive status RPC
- drain in-flight fee work before publishing authority disabled, with bounded fail-closed timeout behavior
- gate scheduled, manual, direct-controller, failed-forward, policy-change, wake, channel-open, and dynamic htlcmax mutation paths
- document restart-persistent handoff, Rust-first rollback ordering, and CLN config.setconfig source verification
- pin RPC/config compatibility inventories and guard the normative Config catalog against drift

## Safety

Python remains enabled by default and remains the sole live fee authority after deployment. This change does not create Rust authority, invoke live action RPCs in tests, or automate handoff/cutover.

## Validation

- independent final review: Ready to merge, no open findings
- pinned environment: pip check clean
- complete exact-head suite: 3896 passed, 5 skipped, 2 xfailed, 0 failed
- focused authority/operator/daemon layer: 237 passed
